### PR TITLE
feat(admin): upgrade content forms for media workflows

### DIFF
--- a/app/Facades/SiteContent.php
+++ b/app/Facades/SiteContent.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Facades;
+
+use Illuminate\Support\Facades\Facade;
+
+/**
+ * @method static mixed getSetting(string $section, string $key, mixed $default = null)
+ * @method static void forgetSetting(string $section, string $key)
+ * @method static \Illuminate\Support\Collection|\App\Models\MediaAsset|null getMedia(string $collection, ?string $key = null)
+ * @method static string url(\App\Models\MediaAsset $asset)
+ *
+ * @see \App\Support\SiteContent
+ */
+class SiteContent extends Facade
+{
+    protected static function getFacadeAccessor(): string
+    {
+        return \App\Support\SiteContent::class;
+    }
+}

--- a/app/Http/Controllers/Admin/SettingController.php
+++ b/app/Http/Controllers/Admin/SettingController.php
@@ -2,21 +2,48 @@
 
 namespace App\Http\Controllers\Admin;
 
+use App\Facades\SiteContent;
 use App\Http\Controllers\Controller;
-use App\Models\SiteSetting;
+use App\Http\Controllers\Traits\HandlesMediaUpload;
+use App\Models\MediaAsset;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\Rule;
 use Inertia\Inertia;
 use Inertia\Response;
 
 class SettingController extends Controller
 {
+    use HandlesMediaUpload;
+
     public function edit(): Response
     {
-        $settings = SiteSetting::first();
+        $generalKeys = [
+            'site_name',
+            'tagline',
+            'address',
+            'phone',
+            'whatsapp',
+            'email',
+            'social',
+            'footer_hours',
+            'ogImage',
+        ];
+
+        $settings = collect($generalKeys)->mapWithKeys(function (string $key) {
+            return [$key => SiteContent::getSetting('general', $key)];
+        })->all();
+
+        $logo = SiteContent::getMedia('logo', 'global');
+        $ogAsset = SiteContent::getMedia('og', 'global');
 
         return Inertia::render('admin/settings/General', [
-            'settings' => $settings,
+            'settings' => array_merge($settings, [
+                'logo_url' => $logo instanceof MediaAsset ? SiteContent::url($logo) : null,
+                'og_image_url' => $ogAsset instanceof MediaAsset ? SiteContent::url($ogAsset) : null,
+            ]),
         ]);
     }
 
@@ -27,21 +54,99 @@ class SettingController extends Controller
             'tagline' => ['nullable', 'string', 'max:255'],
             'address' => ['nullable', 'string', 'max:255'],
             'phone' => ['nullable', 'string', 'max:255'],
-            'fax' => ['nullable', 'string', 'max:255'],
-            'email' => ['nullable', 'string', 'max:255'],
-            'logo_path' => ['nullable', 'string', 'max:255'],
-            'logo' => ['nullable', 'image', 'max:2048'],
+            'whatsapp' => ['nullable', 'string', 'max:255'],
+            'email' => ['nullable', 'email', 'max:255'],
+            'social' => ['nullable', 'array'],
+            'social.*.label' => ['required_with:social', 'string', 'max:120'],
+            'social.*.url' => ['required_with:social', 'url', 'max:255'],
+            'footer_hours' => ['nullable', 'array'],
+            'footer_hours.*.day' => ['required_with:footer_hours', 'string', 'max:32'],
+            'footer_hours.*.time' => ['required_with:footer_hours', 'string', 'max:64'],
+            'logo' => ['nullable', 'image', Rule::dimensions()->minWidth(300)->minHeight(300), 'max:3072', 'mimes:jpg,jpeg,png,webp'],
+            'og_image' => ['nullable', 'image', Rule::dimensions()->minWidth(1200)->minHeight(630), 'max:3072', 'mimes:jpg,jpeg,png,webp'],
         ]);
 
-        $settings = SiteSetting::first() ?? new SiteSetting();
+        DB::transaction(function () use ($data, $request) {
+            $payload = Arr::only($data, [
+                'site_name',
+                'tagline',
+                'address',
+                'phone',
+                'whatsapp',
+                'email',
+                'social',
+                'footer_hours',
+            ]);
 
-        if ($request->hasFile('logo')) {
-            $path = $request->file('logo')->store('logos', 'public');
-            $data['logo_path'] = $path;
-        }
+            if ($request->hasFile('logo')) {
+                $logo = $this->storeMedia(
+                    $request->file('logo'),
+                    'logo',
+                    'global',
+                    $data['site_name'] ?? null
+                );
 
-        $settings->fill($data)->save();
+                $payload['logo'] = [
+                    'id' => $logo->id,
+                    'path' => $logo->path,
+                ];
+            } else {
+                $existingLogo = SiteContent::getMedia('logo', 'global');
+
+                if ($existingLogo instanceof MediaAsset) {
+                    $payload['logo'] = [
+                        'id' => $existingLogo->id,
+                        'path' => $existingLogo->path,
+                    ];
+                }
+            }
+
+            if ($request->hasFile('og_image')) {
+                $ogAsset = $this->storeMedia(
+                    $request->file('og_image'),
+                    'og',
+                    'global',
+                    'Default OpenGraph'
+                );
+
+                $payload['ogImage'] = [
+                    'id' => $ogAsset->id,
+                    'path' => $ogAsset->path,
+                ];
+            }
+
+            $this->persistSettings($payload);
+        });
 
         return back()->with('success', 'Pengaturan disimpan');
+    }
+
+    private function persistSettings(array $values): void
+    {
+        if ($values === []) {
+            return;
+        }
+
+        $now = now();
+
+        $records = collect($values)->map(function ($value, string $key) use ($now) {
+            return [
+                'section' => 'general',
+                'key' => $key,
+                'value_json' => json_encode($value),
+                'created_at' => $now,
+                'updated_at' => $now,
+            ];
+        })->values()->all();
+
+        DB::table('site_settings')->upsert(
+            $records,
+            ['section', 'key'],
+            ['value_json', 'updated_at']
+        );
+
+        foreach (array_keys($values) as $key) {
+            SiteContent::forgetSetting('general', $key);
+        }
     }
 }

--- a/app/Http/Controllers/Public/AlbumController.php
+++ b/app/Http/Controllers/Public/AlbumController.php
@@ -2,9 +2,9 @@
 
 namespace App\Http\Controllers\Public;
 
+use App\Facades\SiteContent;
 use App\Http\Controllers\Controller;
 use App\Models\Album;
-use App\Models\SiteSetting;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -12,7 +12,7 @@ class AlbumController extends Controller
 {
     public function index(): Response
     {
-        $settings = SiteSetting::first();
+        $settings = $this->generalSettings();
         $albums = Album::query()
             ->withCount('media')
             ->orderByDesc('created_at')
@@ -26,7 +26,7 @@ class AlbumController extends Controller
 
     public function show(string $slug): Response
     {
-        $settings = SiteSetting::first();
+        $settings = $this->generalSettings();
         $album = Album::query()
             ->with('media')
             ->where('slug', $slug)
@@ -36,5 +36,13 @@ class AlbumController extends Controller
             'settings' => $settings,
             'album' => $album,
         ]);
+    }
+
+    private function generalSettings(): array
+    {
+        return [
+            'site_name' => SiteContent::getSetting('general', 'site_name'),
+            'tagline' => SiteContent::getSetting('general', 'tagline'),
+        ];
     }
 }

--- a/app/Http/Controllers/Public/ContactController.php
+++ b/app/Http/Controllers/Public/ContactController.php
@@ -2,9 +2,9 @@
 
 namespace App\Http\Controllers\Public;
 
+use App\Facades\SiteContent;
 use App\Http\Controllers\Controller;
 use App\Models\ContactMessage;
-use App\Models\SiteSetting;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
@@ -14,7 +14,10 @@ class ContactController extends Controller
 {
     public function form(): Response
     {
-        $settings = SiteSetting::first();
+        $settings = [
+            'site_name' => SiteContent::getSetting('general', 'site_name'),
+            'tagline' => SiteContent::getSetting('general', 'tagline'),
+        ];
         return Inertia::render('public/Contact', [
             'settings' => $settings,
         ]);

--- a/app/Http/Controllers/Public/EventController.php
+++ b/app/Http/Controllers/Public/EventController.php
@@ -2,9 +2,9 @@
 
 namespace App\Http\Controllers\Public;
 
+use App\Facades\SiteContent;
 use App\Http\Controllers\Controller;
 use App\Models\Event;
-use App\Models\SiteSetting;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
 use Inertia\Response;
@@ -13,7 +13,7 @@ class EventController extends Controller
 {
     public function index(Request $request): Response
     {
-        $settings = SiteSetting::first();
+        $settings = $this->generalSettings();
         $filter = $request->string('filter')->toString();
 
         $query = Event::query()->orderBy('start_at');
@@ -37,12 +37,20 @@ class EventController extends Controller
 
     public function show(string $slug): Response
     {
-        $settings = SiteSetting::first();
+        $settings = $this->generalSettings();
         $event = Event::query()->where('slug', $slug)->firstOrFail();
 
         return Inertia::render('agenda/Detail', [
             'settings' => $settings,
             'event' => $event,
         ]);
+    }
+
+    private function generalSettings(): array
+    {
+        return [
+            'site_name' => SiteContent::getSetting('general', 'site_name'),
+            'tagline' => SiteContent::getSetting('general', 'tagline'),
+        ];
     }
 }

--- a/app/Http/Controllers/Public/HomeController.php
+++ b/app/Http/Controllers/Public/HomeController.php
@@ -2,12 +2,12 @@
 
 namespace App\Http\Controllers\Public;
 
+use App\Facades\SiteContent;
 use App\Http\Controllers\Controller;
 use App\Models\Album;
 use App\Models\Event;
 use App\Models\Page;
 use App\Models\Post;
-use App\Models\SiteSetting;
 use App\Models\VocationalProgram;
 use Illuminate\Support\Str;
 use Inertia\Inertia;
@@ -17,7 +17,10 @@ class HomeController extends Controller
 {
     public function index(): Response
     {
-        $settings = SiteSetting::first();
+        $settings = [
+            'site_name' => SiteContent::getSetting('general', 'site_name'),
+            'tagline' => SiteContent::getSetting('general', 'tagline'),
+        ];
 
         $profilePage = Page::query()->where('slug', 'profil')->first(['title', 'content']);
         $profileExcerpt = $profilePage ? Str::limit(strip_tags($profilePage->content), 250) : null;

--- a/app/Http/Controllers/Public/PageController.php
+++ b/app/Http/Controllers/Public/PageController.php
@@ -2,9 +2,9 @@
 
 namespace App\Http\Controllers\Public;
 
+use App\Facades\SiteContent;
 use App\Http\Controllers\Controller;
 use App\Models\Page;
-use App\Models\SiteSetting;
 use Illuminate\Support\Str;
 use Inertia\Inertia;
 use Inertia\Response;
@@ -13,7 +13,7 @@ class PageController extends Controller
 {
     public function showProfile(): Response
     {
-        $settings = SiteSetting::first();
+        $settings = $this->generalSettings();
         $page = Page::where('slug', 'profil')->first();
 
         return Inertia::render('public/Profile', [
@@ -24,7 +24,7 @@ class PageController extends Controller
 
     public function showVisionMission(): Response
     {
-        $settings = SiteSetting::first();
+        $settings = $this->generalSettings();
         $page = Page::where('slug', 'visi-misi')->first();
 
         $vision = null;
@@ -52,5 +52,13 @@ class PageController extends Controller
             'vision' => $vision,
             'missions' => $missions,
         ]);
+    }
+
+    private function generalSettings(): array
+    {
+        return [
+            'site_name' => SiteContent::getSetting('general', 'site_name'),
+            'tagline' => SiteContent::getSetting('general', 'tagline'),
+        ];
     }
 }

--- a/app/Http/Controllers/Public/PostController.php
+++ b/app/Http/Controllers/Public/PostController.php
@@ -2,9 +2,9 @@
 
 namespace App\Http\Controllers\Public;
 
+use App\Facades\SiteContent;
 use App\Http\Controllers\Controller;
 use App\Models\Post;
-use App\Models\SiteSetting;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
 use Inertia\Response;
@@ -13,7 +13,7 @@ class PostController extends Controller
 {
     public function index(Request $request): Response
     {
-        $settings = SiteSetting::first();
+        $settings = $this->generalSettings();
         $posts = Post::query()
             ->published()
             ->orderByDesc('published_at')
@@ -28,7 +28,7 @@ class PostController extends Controller
 
     public function show(string $slug): Response
     {
-        $settings = SiteSetting::first();
+        $settings = $this->generalSettings();
         $post = Post::query()
             ->published()
             ->where('slug', $slug)
@@ -46,5 +46,13 @@ class PostController extends Controller
             'post' => $post,
             'related' => $related,
         ]);
+    }
+
+    private function generalSettings(): array
+    {
+        return [
+            'site_name' => SiteContent::getSetting('general', 'site_name'),
+            'tagline' => SiteContent::getSetting('general', 'tagline'),
+        ];
     }
 }

--- a/app/Http/Controllers/Public/VocationalController.php
+++ b/app/Http/Controllers/Public/VocationalController.php
@@ -2,8 +2,8 @@
 
 namespace App\Http\Controllers\Public;
 
+use App\Facades\SiteContent;
 use App\Http\Controllers\Controller;
-use App\Models\SiteSetting;
 use App\Models\VocationalProgram;
 use Inertia\Inertia;
 use Inertia\Response;
@@ -12,28 +12,36 @@ class VocationalController extends Controller
 {
     public function index(): Response
     {
-        $settings = SiteSetting::first();
+        $settings = $this->generalSettings();
         $items = VocationalProgram::with('media')
             ->select('id', 'slug', 'title', 'description', 'duration', 'schedule')
             ->get();
 
         return Inertia::render('vocational/Index', [
-            'settings' => $settings->toArray(),
+            'settings' => $settings,
             'items' => $items,
         ]);
     }
 
     public function show(string $slug): Response
     {
-        $settings = SiteSetting::first();
+        $settings = $this->generalSettings();
         $program = VocationalProgram::with('media')
             ->select('id', 'slug', 'title', 'icon', 'description', 'audience', 'duration', 'schedule', 'outcomes', 'facilities', 'mentors', 'photos')
             ->where('slug', $slug)
             ->firstOrFail();
 
         return Inertia::render('vocational/Detail', [
-            'settings' => $settings->toArray(),
+            'settings' => $settings,
             'program' => $program,
         ]);
+    }
+
+    private function generalSettings(): array
+    {
+        return [
+            'site_name' => SiteContent::getSetting('general', 'site_name'),
+            'tagline' => SiteContent::getSetting('general', 'tagline'),
+        ];
     }
 }

--- a/app/Http/Controllers/Traits/HandlesMediaUpload.php
+++ b/app/Http/Controllers/Traits/HandlesMediaUpload.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Http\Controllers\Traits;
+
+use App\Models\MediaAsset;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+
+trait HandlesMediaUpload
+{
+    protected function storeMedia(
+        UploadedFile $file,
+        string $collection,
+        ?string $key = null,
+        ?string $alt = null,
+        bool $replaceExisting = true
+    ): MediaAsset {
+        $disk = 'public';
+        $directory = sprintf('%s/%s', $collection, now()->format('Y/m'));
+        $filename = sprintf('%s.%s', (string) Str::uuid(), $file->getClientOriginalExtension());
+        $path = $file->storeAs($directory, $filename, $disk);
+
+        $attributes = [
+            'collection' => $collection,
+            'key' => $key,
+            'disk' => $disk,
+            'path' => $path,
+            'type' => $file->getMimeType() ?? $file->getClientOriginalExtension(),
+            'alt' => $alt,
+        ];
+
+        if ($replaceExisting) {
+            $existing = MediaAsset::query()
+                ->where('collection', $collection)
+                ->when($key !== null, fn ($query) => $query->where('key', $key))
+                ->first();
+
+            if ($existing) {
+                $this->deleteAssetFile($existing);
+
+                $existing->fill($attributes);
+                $existing->save();
+
+                return $existing;
+            }
+        }
+
+        return MediaAsset::create($attributes);
+    }
+
+    protected function deleteAssetFile(MediaAsset $asset): void
+    {
+        $disk = $asset->disk ?: 'public';
+
+        if (Storage::disk($disk)->exists($asset->path)) {
+            Storage::disk($disk)->delete($asset->path);
+        }
+    }
+}
+

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Middleware;
 
+use App\Facades\SiteContent;
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Http\Request;
 use Inertia\Middleware;
@@ -46,6 +47,26 @@ class HandleInertiaRequests extends Middleware
                 'user' => $request->user(),
             ],
             'sidebarOpen' => ! $request->hasCookie('sidebar_state') || $request->cookie('sidebar_state') === 'true',
+            'settings' => $this->publicSettings(),
+        ];
+    }
+
+    private function publicSettings(): array
+    {
+        $logo = SiteContent::getMedia('logo', 'global');
+        $og = SiteContent::getMedia('og', 'global');
+
+        return [
+            'name' => SiteContent::getSetting('general', 'site_name'),
+            'tagline' => SiteContent::getSetting('general', 'tagline'),
+            'logo_url' => $logo ? SiteContent::url($logo) : null,
+            'phone' => SiteContent::getSetting('general', 'phone'),
+            'whatsapp' => SiteContent::getSetting('general', 'whatsapp'),
+            'email' => SiteContent::getSetting('general', 'email'),
+            'address' => SiteContent::getSetting('general', 'address'),
+            'social' => SiteContent::getSetting('general', 'social', []),
+            'footer_hours' => SiteContent::getSetting('general', 'footer_hours', []),
+            'og_image_url' => $og ? SiteContent::url($og) : null,
         ];
     }
 }

--- a/app/Models/MediaAsset.php
+++ b/app/Models/MediaAsset.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class MediaAsset extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'collection',
+        'key',
+        'disk',
+        'path',
+        'type',
+        'alt',
+        'focal_x',
+        'focal_y',
+    ];
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,10 @@
 
 namespace App\Providers;
 
+use App\Support\SiteContent;
+use Illuminate\Contracts\Cache\Factory as CacheFactory;
+use Illuminate\Contracts\Filesystem\Factory as FilesystemFactory;
+use Illuminate\Database\DatabaseManager;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -11,7 +15,13 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        //
+        $this->app->singleton(SiteContent::class, function ($app) {
+            return new SiteContent(
+                $app->make(DatabaseManager::class)->connection(),
+                $app->make(CacheFactory::class)->store(),
+                $app->make(FilesystemFactory::class),
+            );
+        });
     }
 
     /**

--- a/app/Support/SiteContent.php
+++ b/app/Support/SiteContent.php
@@ -1,0 +1,180 @@
+<?php
+
+namespace App\Support;
+
+use App\Models\MediaAsset;
+use Illuminate\Contracts\Cache\Repository as CacheRepository;
+use Illuminate\Contracts\Filesystem\Factory as FilesystemFactory;
+use Illuminate\Database\ConnectionInterface;
+use Illuminate\Database\Query\Builder;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+
+class SiteContent
+{
+    private const CACHE_KEY_FORMAT = 'site:set:%s:%s';
+
+    public function __construct(
+        private readonly ConnectionInterface $connection,
+        private readonly CacheRepository $cache,
+        private readonly FilesystemFactory $storage
+    ) {
+    }
+
+    /**
+     * Retrieve a structured site setting value with caching.
+     */
+    public function getSetting(string $section, string $key, mixed $default = null): mixed
+    {
+        $cacheKey = sprintf(self::CACHE_KEY_FORMAT, $section, $key);
+
+        return $this->cache->remember($cacheKey, now()->addMinutes(10), function () use ($section, $key, $default) {
+            $record = $this->builder()
+                ->where('section', $section)
+                ->where('key', $key)
+                ->first();
+
+            if (! $record) {
+                return $default;
+            }
+
+            $value = $record->value_json ?? null;
+
+            if (is_string($value)) {
+                $decoded = json_decode($value, true);
+
+                if (json_last_error() === JSON_ERROR_NONE) {
+                    return $decoded;
+                }
+
+                return $value;
+            }
+
+            if (is_array($value)) {
+                return $value;
+            }
+
+            if (is_object($value)) {
+                return json_decode(json_encode($value), true);
+            }
+
+            return $value ?? $default;
+        });
+    }
+
+    public function forgetSetting(string $section, string $key): void
+    {
+        $cacheKey = sprintf(self::CACHE_KEY_FORMAT, $section, $key);
+
+        $this->cache->forget($cacheKey);
+    }
+
+    /**
+     * Fetch media assets for a collection optionally scoped by key.
+     */
+    public function getMedia(string $collection, ?string $key = null): Collection|MediaAsset|null
+    {
+        $query = MediaAsset::query()->where('collection', $collection);
+
+        if ($key !== null) {
+            $asset = $query->where('key', $key)->first();
+
+            if ($collection === 'og' && ! $asset) {
+                return $this->ogFallback();
+            }
+
+            return $asset;
+        }
+
+        $assets = $query->orderBy('id')->get();
+
+        if ($collection === 'og' && $assets->isEmpty()) {
+            $fallback = $this->ogFallback();
+
+            if ($fallback) {
+                return collect([$fallback]);
+            }
+        }
+
+        return $assets;
+    }
+
+    /**
+     * Build a publicly accessible URL for the given media asset.
+     */
+    public function url(MediaAsset $asset): string
+    {
+        $path = $asset->path;
+
+        if (Str::startsWith($path, ['http://', 'https://'])) {
+            return $path;
+        }
+
+        $disk = $asset->disk ?: 'public';
+
+        return $this->storage->disk($disk)->url($path);
+    }
+
+    private function builder(): Builder
+    {
+        return $this->connection->table('site_settings')->select('value_json');
+    }
+
+    public function ogFallback(): ?MediaAsset
+    {
+        $fallback = $this->getSetting('general', 'ogImage');
+
+        return $this->normaliseMediaFallback($fallback);
+    }
+
+    private function normaliseMediaFallback(mixed $fallback): ?MediaAsset
+    {
+        if (! $fallback) {
+            return null;
+        }
+
+        if ($fallback instanceof MediaAsset) {
+            return $fallback;
+        }
+
+        if (is_numeric($fallback)) {
+            return MediaAsset::find((int) $fallback);
+        }
+
+        if (is_array($fallback)) {
+            if (isset($fallback['id'])) {
+                return MediaAsset::find((int) $fallback['id']);
+            }
+
+            if (! isset($fallback['path'])) {
+                return null;
+            }
+
+            $attributes = array_intersect_key($fallback, array_flip([
+                'collection',
+                'key',
+                'disk',
+                'path',
+                'type',
+                'alt',
+                'focal_x',
+                'focal_y',
+            ]));
+
+            $attributes['collection'] = $attributes['collection'] ?? 'og';
+            $attributes['disk'] = $attributes['disk'] ?? 'public';
+
+            return MediaAsset::make($attributes);
+        }
+
+        if (is_string($fallback)) {
+            return MediaAsset::make([
+                'collection' => 'og',
+                'disk' => 'public',
+                'path' => $fallback,
+            ]);
+        }
+
+        return null;
+    }
+}

--- a/database/migrations/2025_10_01_000200_create_media_assets_table.php
+++ b/database/migrations/2025_10_01_000200_create_media_assets_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('media_assets', function (Blueprint $table) {
+            $table->id();
+            $table->enum('collection', ['logo', 'hero', 'cover', 'gallery', 'og']);
+            $table->string('key')->nullable();
+            $table->string('disk')->default('public');
+            $table->string('path');
+            $table->string('type');
+            $table->string('alt')->nullable();
+            $table->tinyInteger('focal_x')->nullable();
+            $table->tinyInteger('focal_y')->nullable();
+            $table->timestamps();
+
+            $table->index(['collection', 'key']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('media_assets');
+    }
+};

--- a/database/migrations/2025_10_01_000210_normalize_site_settings.php
+++ b/database/migrations/2025_10_01_000210_normalize_site_settings.php
@@ -1,0 +1,113 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        if (Schema::hasTable('site_settings') && Schema::hasColumn('site_settings', 'section')) {
+            return;
+        }
+
+        $temporaryTable = 'new_site_settings';
+
+        Schema::dropIfExists($temporaryTable);
+
+        Schema::create($temporaryTable, function (Blueprint $table) {
+            $table->id();
+            $table->string('section');
+            $table->string('key');
+            $table->json('value_json');
+            $table->timestamps();
+            $table->unique(['section', 'key']);
+        });
+
+        if (Schema::hasTable('site_settings')) {
+            $existing = DB::table('site_settings')->first();
+
+            if ($existing) {
+                $payload = collect((array) $existing)
+                    ->except(['id', 'created_at', 'updated_at'])
+                    ->filter(fn ($value) => $value !== null);
+
+                $now = now();
+
+                $records = $payload->map(function ($value, $key) use ($now) {
+                    return [
+                        'section' => 'general',
+                        'key' => $key,
+                        'value_json' => json_encode($value),
+                        'created_at' => $now,
+                        'updated_at' => $now,
+                    ];
+                })->values();
+
+                if ($records->isNotEmpty()) {
+                    DB::table($temporaryTable)->insert($records->all());
+                }
+            }
+
+            Schema::drop('site_settings');
+        }
+
+        Schema::rename($temporaryTable, 'site_settings');
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasTable('site_settings') || ! Schema::hasColumn('site_settings', 'section')) {
+            return;
+        }
+
+        if (Schema::hasTable('normalized_site_settings')) {
+            Schema::drop('normalized_site_settings');
+        }
+
+        Schema::rename('site_settings', 'normalized_site_settings');
+
+        Schema::create('site_settings', function (Blueprint $table) {
+            $table->id();
+            $table->string('site_name')->default('Vokasional Disabilitas');
+            $table->string('tagline')->nullable();
+            $table->string('address')->nullable();
+            $table->string('phone')->nullable();
+            $table->string('fax')->nullable();
+            $table->string('email')->nullable();
+            $table->string('logo_path')->nullable();
+            $table->timestamps();
+        });
+
+        $generalSettings = DB::table('normalized_site_settings')
+            ->where('section', 'general')
+            ->pluck('value_json', 'key');
+
+        if ($generalSettings->isNotEmpty()) {
+            $decode = static function (?string $json, $default = null) {
+                if ($json === null) {
+                    return $default;
+                }
+
+                $decoded = json_decode($json, true);
+
+                return $decoded === null ? $default : $decoded;
+            };
+
+            DB::table('site_settings')->insert([
+                'site_name' => $decode($generalSettings->get('site_name'), 'Vokasional Disabilitas'),
+                'tagline' => $decode($generalSettings->get('tagline')),
+                'address' => $decode($generalSettings->get('address')),
+                'phone' => $decode($generalSettings->get('phone')),
+                'fax' => $decode($generalSettings->get('fax')),
+                'email' => $decode($generalSettings->get('email')),
+                'logo_path' => $decode($generalSettings->get('logo_path')),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+        }
+
+        Schema::dropIfExists('normalized_site_settings');
+    }
+};

--- a/resources/js/components/SectionHeading.tsx
+++ b/resources/js/components/SectionHeading.tsx
@@ -1,5 +1,3 @@
-import type { PropsWithChildren } from 'react';
-
 interface SectionHeadingProps {
     title: string;
     desc?: string;

--- a/resources/js/components/ui/Breadcrumbs.tsx
+++ b/resources/js/components/ui/Breadcrumbs.tsx
@@ -10,22 +10,39 @@ export type Crumb = {
 type BreadcrumbsProps = {
     items: Crumb[];
     className?: string;
+    variant?: 'light' | 'dark';
 };
 
-export default function Breadcrumbs({ items, className }: BreadcrumbsProps) {
+export default function Breadcrumbs({ items, className, variant = 'light' }: BreadcrumbsProps) {
     if (!items.length) {
         return null;
     }
 
+    const navClass = cn(
+        'flex items-center gap-2 text-sm text-slate-500',
+        variant === 'dark' && 'text-slate-200',
+        className,
+    );
+
+    const linkClass = cn(
+        'inline-flex items-center gap-1 rounded-lg px-2 py-1 transition focus-visible:outline-none focus-visible:ring-2',
+        variant === 'dark'
+            ? 'text-white hover:bg-white/10 focus-visible:ring-white/40'
+            : 'hover:bg-slate-100 focus-visible:ring-slate-400',
+    );
+
+    const crumbLinkClass = cn(
+        'rounded-lg px-2 py-1 transition focus-visible:outline-none focus-visible:ring-2',
+        variant === 'dark'
+            ? 'text-slate-100 hover:bg-white/10 focus-visible:ring-white/40'
+            : 'hover:bg-slate-100 focus-visible:ring-slate-400',
+    );
+
+    const lastCrumbClass = variant === 'dark' ? 'text-white' : 'text-slate-700';
+
     return (
-        <nav
-            aria-label="Breadcrumb"
-            className={cn('flex items-center gap-2 text-sm text-slate-500', className)}
-        >
-            <a
-                href="/"
-                className="inline-flex items-center gap-1 rounded-lg px-2 py-1 transition hover:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400"
-            >
+        <nav aria-label="Breadcrumb" className={navClass}>
+            <a href="/" className={linkClass}>
                 <Home size={14} aria-hidden />
                 <span>Beranda</span>
             </a>
@@ -35,11 +52,11 @@ export default function Breadcrumbs({ items, className }: BreadcrumbsProps) {
                     <React.Fragment key={`${item.label}-${index}`}>
                         <span aria-hidden="true">/</span>
                         {isLast || !item.href ? (
-                            <span className="text-slate-700">{item.label}</span>
+                            <span className={lastCrumbClass}>{item.label}</span>
                         ) : (
                             <a
                                 href={item.href}
-                                className="rounded-lg px-2 py-1 transition hover:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400"
+                                className={crumbLinkClass}
                             >
                                 {item.label}
                             </a>

--- a/resources/js/pages/admin/albums/Form.tsx
+++ b/resources/js/pages/admin/albums/Form.tsx
@@ -2,6 +2,10 @@ import React, { useState } from 'react';
 import { router, usePage } from '@inertiajs/react';
 import AdminLayout from '@/pages/admin/_layout/AdminLayout';
 
+type PagePropsWithErrors = {
+    errors?: Record<string, string>;
+};
+
 interface AlbumFormProps {
     album?: {
         id: number;
@@ -23,8 +27,8 @@ interface AlbumFormProps {
 
 export default function AlbumForm({ album }: AlbumFormProps) {
     const isEdit = Boolean(album?.id);
-    const { props } = usePage();
-    const errors = (props as any)?.errors as Record<string, string> | undefined;
+    const { props } = usePage<PagePropsWithErrors>();
+    const errors = props.errors;
 
     const [form, setForm] = useState({
         title: album?.title ?? '',

--- a/resources/js/pages/admin/content/Edit.tsx
+++ b/resources/js/pages/admin/content/Edit.tsx
@@ -1,0 +1,647 @@
+import { useEffect, useState } from 'react';
+import { useForm, usePage } from '@inertiajs/react';
+import AdminLayout from '@/pages/admin/_layout/AdminLayout';
+
+type SectionKey = 'home' | 'profil' | 'visi';
+
+type Highlight = {
+    icon: string;
+    title: string;
+    description: string;
+    link: string;
+};
+
+type Testimonial = {
+    name: string;
+    role: string;
+    quote: string;
+};
+
+type HeroSettings = {
+    title: string;
+    subtitle: string;
+    cta1_label: string;
+    cta1_url: string;
+    cta2_label: string;
+    cta2_url: string;
+    overlay: number;
+};
+
+type ContentSettings = {
+    hero?: HeroSettings & { alt?: string };
+    highlights?: Highlight[];
+    newsMode?: 'auto' | 'manual';
+    pins?: number[];
+    agendaLimit?: number;
+    galleryMode?: 'album' | 'manual';
+    galleryAlbumId?: number | string | null;
+    galleryManual?: number[];
+    stats?: {
+        students?: number;
+        teachers?: number;
+        accreditation?: string;
+        photos?: number;
+    };
+    testimonials?: Testimonial[];
+    showHighlights?: boolean;
+    showStats?: boolean;
+    showTestimonials?: boolean;
+};
+
+type PageProps = {
+    section: SectionKey;
+    settings?: ContentSettings | null;
+    hero_url?: string | null;
+    flash?: { success?: string };
+    updateUrl?: string;
+    availableNews?: Array<{ id: number; title: string }>;
+    galleryAlbums?: Array<{ id: number; name: string }>;
+};
+
+type FormValues = {
+    section: SectionKey;
+    heroFile: File | null;
+    heroAlt: string;
+    hero: HeroSettings;
+    highlights: Highlight[];
+    showHighlights: boolean;
+    newsMode: 'auto' | 'manual';
+    pins: number[];
+    agendaLimit: number;
+    galleryMode: 'album' | 'manual';
+    galleryAlbumId: string;
+    galleryManual: string;
+    stats: {
+        students: string;
+        teachers: string;
+        accreditation: string;
+        photos: string;
+    };
+    showStats: boolean;
+    testimonials: Testimonial[];
+    showTestimonials: boolean;
+};
+
+const DEFAULT_HERO: HeroSettings = {
+    title: '',
+    subtitle: '',
+    cta1_label: '',
+    cta1_url: '',
+    cta2_label: '',
+    cta2_url: '',
+    overlay: 60,
+};
+
+const buildHighlights = (initial?: Highlight[]): Highlight[] => {
+    const base = initial ?? [];
+    return Array.from({ length: 4 }).map((_, index) => base[index] ?? { icon: '', title: '', description: '', link: '' });
+};
+
+const buildTestimonials = (initial?: Testimonial[]): Testimonial[] => {
+    if (!initial || initial.length === 0) {
+        return [
+            {
+                name: '',
+                role: '',
+                quote: '',
+            },
+        ];
+    }
+
+    return initial;
+};
+
+function Toast({ message }: { message: string }) {
+    return (
+        <div className="fixed bottom-6 right-6 z-50 rounded-xl bg-slate-900 px-4 py-3 text-sm font-semibold text-white shadow-xl dark:bg-emerald-500">
+            {message}
+        </div>
+    );
+}
+
+export default function ContentEdit() {
+    const { props } = usePage<PageProps>();
+    const section = props.section;
+    const settings = props.settings ?? {};
+    const availableNews = props.availableNews ?? [];
+    const albums = props.galleryAlbums ?? [];
+
+    const [toastMessage, setToastMessage] = useState<string | null>(props.flash?.success ?? null);
+    const [heroPreview, setHeroPreview] = useState<string | null>(props.hero_url ?? null);
+    const [heroWarning, setHeroWarning] = useState<string | null>(null);
+
+    const { data, setData, post, processing, errors, reset } = useForm<FormValues>({
+        section,
+        heroFile: null,
+        heroAlt: settings.hero?.alt ?? '',
+        hero: {
+            title: settings.hero?.title ?? DEFAULT_HERO.title,
+            subtitle: settings.hero?.subtitle ?? DEFAULT_HERO.subtitle,
+            cta1_label: settings.hero?.cta1_label ?? DEFAULT_HERO.cta1_label,
+            cta1_url: settings.hero?.cta1_url ?? DEFAULT_HERO.cta1_url,
+            cta2_label: settings.hero?.cta2_label ?? DEFAULT_HERO.cta2_label,
+            cta2_url: settings.hero?.cta2_url ?? DEFAULT_HERO.cta2_url,
+            overlay: settings.hero?.overlay ?? DEFAULT_HERO.overlay,
+        },
+        highlights: buildHighlights(settings.highlights),
+        showHighlights: settings.showHighlights ?? true,
+        newsMode: settings.newsMode ?? 'auto',
+        pins: settings.pins ?? [],
+        agendaLimit: settings.agendaLimit ?? 3,
+        galleryMode: settings.galleryMode ?? 'album',
+        galleryAlbumId: settings.galleryAlbumId ? String(settings.galleryAlbumId) : '',
+        galleryManual: settings.galleryManual?.join(', ') ?? '',
+        stats: {
+            students: settings.stats?.students != null ? String(settings.stats.students) : '',
+            teachers: settings.stats?.teachers != null ? String(settings.stats.teachers) : '',
+            accreditation: settings.stats?.accreditation ?? '',
+            photos: settings.stats?.photos != null ? String(settings.stats.photos) : '',
+        },
+        showStats: settings.showStats ?? true,
+        testimonials: buildTestimonials(settings.testimonials),
+        showTestimonials: settings.showTestimonials ?? true,
+    });
+
+    const actionUrl = props.updateUrl ?? `/admin/content/${section}`;
+
+    useEffect(() => {
+        if (props.flash?.success) {
+            setToastMessage(props.flash.success);
+            const timeout = setTimeout(() => setToastMessage(null), 3500);
+            return () => clearTimeout(timeout);
+        }
+
+        return undefined;
+    }, [props.flash?.success]);
+
+    useEffect(
+        () => () => {
+            if (heroPreview && heroPreview.startsWith('blob:')) {
+                URL.revokeObjectURL(heroPreview);
+            }
+        },
+        [heroPreview],
+    );
+
+    const showToast = (message: string) => {
+        setToastMessage(message);
+        setTimeout(() => setToastMessage(null), 3500);
+    };
+
+    const handleHeroChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+        const file = event.target.files?.[0] ?? null;
+        setData('heroFile', file);
+
+        if (!file) {
+            if (heroPreview && heroPreview.startsWith('blob:')) {
+                URL.revokeObjectURL(heroPreview);
+            }
+            setHeroPreview(props.hero_url ?? null);
+            setHeroWarning(null);
+            return;
+        }
+
+        const previewUrl = URL.createObjectURL(file);
+        setHeroPreview(previewUrl);
+
+        const image = new Image();
+        image.onload = () => {
+            if (image.width < 1600 || image.height < 900) {
+                setHeroWarning('Resolusi hero minimal 1600x900 piksel. Unggah ulang untuk hasil terbaik.');
+            } else {
+                setHeroWarning(null);
+            }
+        };
+        image.src = previewUrl;
+    };
+
+    const updateHighlight = (index: number, key: keyof Highlight, value: string) => {
+        const next = [...data.highlights];
+        next[index] = { ...next[index], [key]: value };
+        setData('highlights', next);
+    };
+
+    const addTestimonial = () => {
+        setData('testimonials', [...data.testimonials, { name: '', role: '', quote: '' }]);
+    };
+
+    const updateTestimonial = (index: number, key: keyof Testimonial, value: string) => {
+        const next = [...data.testimonials];
+        next[index] = { ...next[index], [key]: value };
+        setData('testimonials', next);
+    };
+
+    const removeTestimonial = (index: number) => {
+        const next = data.testimonials.filter((_, idx) => idx !== index);
+        setData('testimonials', next.length > 0 ? next : [{ name: '', role: '', quote: '' }]);
+    };
+
+    const togglePin = (id: number) => {
+        if (data.pins.includes(id)) {
+            setData('pins', data.pins.filter((pin) => pin !== id));
+        } else {
+            setData('pins', [...data.pins, id]);
+        }
+    };
+
+    const submit = (event: React.FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+
+        const payload: Record<string, unknown> = {
+            section: data.section,
+            hero: data.hero,
+            hero_alt: data.heroAlt,
+            showHighlights: data.showHighlights,
+            highlights: data.highlights,
+            newsMode: data.newsMode,
+            pins: data.pins,
+            agendaLimit: data.agendaLimit,
+            galleryMode: data.galleryMode,
+            galleryAlbumId: data.galleryAlbumId || null,
+            galleryManual: data.galleryManual
+                .split(',')
+                .map((entry) => entry.trim())
+                .filter(Boolean)
+                .map((entry) => Number(entry)),
+            stats: {
+                students: data.stats.students ? Number(data.stats.students) : null,
+                teachers: data.stats.teachers ? Number(data.stats.teachers) : null,
+                accreditation: data.stats.accreditation,
+                photos: data.stats.photos ? Number(data.stats.photos) : null,
+            },
+            showStats: data.showStats,
+            testimonials: data.testimonials,
+            showTestimonials: data.showTestimonials,
+        };
+
+        if (data.heroFile) {
+            payload.hero_media = data.heroFile;
+        }
+
+        post(actionUrl, {
+            data: payload,
+            forceFormData: true,
+            preserveScroll: true,
+            onSuccess: () => {
+                showToast('Konten berhasil disimpan.');
+                if (!data.heroFile) {
+                    return;
+                }
+                reset('heroFile');
+            },
+        });
+    };
+
+    const isHome = section === 'home';
+
+    return (
+        <AdminLayout title={`Pengaturan Konten: ${section === 'home' ? 'Beranda' : section === 'profil' ? 'Profil' : 'Visi & Misi'}`}>
+            <form onSubmit={submit} className="mx-auto flex w-full max-w-5xl flex-col gap-6" encType="multipart/form-data">
+                <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-800">
+                    <div className="mb-4 flex flex-col gap-2">
+                        <h2 className="text-lg font-semibold text-slate-900 dark:text-white">Hero Section</h2>
+                        <p className="text-sm text-slate-500 dark:text-slate-400">Unggah hero berdimensi 16:9 minimal 1600x900 dan atur teks serta CTA.</p>
+                    </div>
+                    <div className="grid gap-6 md:grid-cols-[minmax(0,320px)_1fr]">
+                        <div className="space-y-3">
+                            <label className="block text-sm font-medium text-slate-700 dark:text-slate-300" htmlFor="hero">Gambar Hero</label>
+                            <input
+                                id="hero"
+                                type="file"
+                                accept="image/jpeg,image/png,image/webp"
+                                onChange={handleHeroChange}
+                                className="block w-full rounded-xl border border-dashed border-slate-300 bg-slate-50 px-3 py-2 text-sm text-slate-600 file:mr-4 file:rounded-lg file:border-0 file:bg-slate-900 file:px-4 file:py-2 file:text-sm file:font-semibold file:text-white hover:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-300 dark:file:bg-slate-700"
+                            />
+                            {heroWarning ? <p className="text-xs text-amber-500">{heroWarning}</p> : null}
+                            {errors.hero_media ? <p className="text-xs text-rose-500">{errors.hero_media}</p> : null}
+                            <input
+                                value={data.heroAlt}
+                                onChange={(event) => setData('heroAlt', event.target.value)}
+                                placeholder="Teks alternatif hero"
+                                className="w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
+                            />
+                            {errors.hero_alt ? <p className="text-xs text-rose-500">{errors.hero_alt}</p> : null}
+                            <label className="block text-sm font-medium text-slate-700 dark:text-slate-300">Overlay</label>
+                            <input
+                                type="range"
+                                min={0}
+                                max={100}
+                                value={data.hero.overlay}
+                                onChange={(event) => setData('hero', { ...data.hero, overlay: Number(event.target.value) })}
+                            />
+                            <p className="text-xs text-slate-500 dark:text-slate-400">Overlay: {data.hero.overlay}%</p>
+                        </div>
+                        <div className="space-y-4">
+                            <div className="overflow-hidden rounded-2xl border border-slate-200 bg-slate-50 p-4 dark:border-slate-600 dark:bg-slate-900">
+                                <p className="text-sm font-semibold text-slate-700 dark:text-slate-200">Pratinjau Hero</p>
+                                <div className="mt-3 h-48 overflow-hidden rounded-xl bg-slate-200 dark:bg-slate-800">
+                                    {heroPreview ? (
+                                        <img src={heroPreview} alt="Hero preview" className="h-full w-full object-cover" />
+                                    ) : (
+                                        <div className="flex h-full items-center justify-center text-sm text-slate-500 dark:text-slate-400">Belum ada gambar hero.</div>
+                                    )}
+                                </div>
+                            </div>
+                            <div className="space-y-3">
+                                <input
+                                    value={data.hero.title}
+                                    onChange={(event) => setData('hero', { ...data.hero, title: event.target.value })}
+                                    placeholder="Judul hero"
+                                    className="w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
+                                />
+                                <textarea
+                                    value={data.hero.subtitle}
+                                    onChange={(event) => setData('hero', { ...data.hero, subtitle: event.target.value })}
+                                    rows={3}
+                                    placeholder="Subjudul hero"
+                                    className="w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
+                                />
+                                <div className="grid gap-3 md:grid-cols-2">
+                                    <div className="space-y-2">
+                                        <input
+                                            value={data.hero.cta1_label}
+                                            onChange={(event) => setData('hero', { ...data.hero, cta1_label: event.target.value })}
+                                            placeholder="Label CTA 1"
+                                            className="w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
+                                        />
+                                        <input
+                                            value={data.hero.cta1_url}
+                                            onChange={(event) => setData('hero', { ...data.hero, cta1_url: event.target.value })}
+                                            placeholder="https://..."
+                                            className="w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
+                                        />
+                                    </div>
+                                    <div className="space-y-2">
+                                        <input
+                                            value={data.hero.cta2_label}
+                                            onChange={(event) => setData('hero', { ...data.hero, cta2_label: event.target.value })}
+                                            placeholder="Label CTA 2"
+                                            className="w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
+                                        />
+                                        <input
+                                            value={data.hero.cta2_url}
+                                            onChange={(event) => setData('hero', { ...data.hero, cta2_url: event.target.value })}
+                                            placeholder="https://..."
+                                            className="w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
+                                        />
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </section>
+
+                {isHome ? (
+                    <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-800">
+                        <div className="mb-4 flex flex-col gap-2">
+                            <div className="flex items-center justify-between">
+                                <h2 className="text-lg font-semibold text-slate-900 dark:text-white">Sorotan &amp; Statistik</h2>
+                                <label className="flex items-center gap-2 text-sm text-slate-600 dark:text-slate-300">
+                                    <input
+                                        type="checkbox"
+                                        checked={data.showHighlights}
+                                        onChange={(event) => setData('showHighlights', event.target.checked)}
+                                        className="h-4 w-4 rounded border-slate-300 text-slate-900 focus:ring-slate-500"
+                                    />
+                                    Tampilkan sorotan
+                                </label>
+                            </div>
+                            <p className="text-sm text-slate-500 dark:text-slate-400">Isi sorotan utama untuk menjelaskan keunggulan sekolah secara singkat.</p>
+                        </div>
+                        <div className="grid gap-4 md:grid-cols-2">
+                            {data.highlights.map((highlight, index) => (
+                                <div key={`highlight-${index}`} className="grid gap-2 rounded-xl border border-slate-200 bg-slate-50 p-4 dark:border-slate-600 dark:bg-slate-900">
+                                    <div className="flex items-center justify-between">
+                                        <h3 className="text-sm font-semibold text-slate-700 dark:text-slate-200">Sorotan {index + 1}</h3>
+                                        <span className="text-xs text-slate-400">Icon library (mis. lucide)</span>
+                                    </div>
+                                    <input
+                                        value={highlight.icon}
+                                        onChange={(event) => updateHighlight(index, 'icon', event.target.value)}
+                                        placeholder="Nama ikon"
+                                        className="rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
+                                    />
+                                    <input
+                                        value={highlight.title}
+                                        onChange={(event) => updateHighlight(index, 'title', event.target.value)}
+                                        placeholder="Judul singkat"
+                                        className="rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
+                                    />
+                                    <textarea
+                                        value={highlight.description}
+                                        onChange={(event) => updateHighlight(index, 'description', event.target.value)}
+                                        rows={3}
+                                        placeholder="Deskripsi singkat"
+                                        className="rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
+                                    />
+                                    <input
+                                        value={highlight.link}
+                                        onChange={(event) => updateHighlight(index, 'link', event.target.value)}
+                                        placeholder="https://..."
+                                        className="rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
+                                    />
+                                </div>
+                            ))}
+                        </div>
+
+                        <div className="mt-6 flex flex-col gap-3 rounded-2xl border border-slate-200 bg-slate-50 p-4 dark:border-slate-600 dark:bg-slate-900">
+                            <div className="flex items-center justify-between">
+                                <h3 className="text-sm font-semibold text-slate-700 dark:text-slate-200">Statistik</h3>
+                                <label className="flex items-center gap-2 text-sm text-slate-600 dark:text-slate-300">
+                                    <input
+                                        type="checkbox"
+                                        checked={data.showStats}
+                                        onChange={(event) => setData('showStats', event.target.checked)}
+                                        className="h-4 w-4 rounded border-slate-300 text-slate-900 focus:ring-slate-500"
+                                    />
+                                    Tampilkan statistik
+                                </label>
+                            </div>
+                            <div className="grid gap-3 md:grid-cols-4">
+                                <input
+                                    value={data.stats.students}
+                                    onChange={(event) => setData('stats', { ...data.stats, students: event.target.value })}
+                                    placeholder="Siswa"
+                                    className="rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
+                                />
+                                <input
+                                    value={data.stats.teachers}
+                                    onChange={(event) => setData('stats', { ...data.stats, teachers: event.target.value })}
+                                    placeholder="Guru"
+                                    className="rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
+                                />
+                                <input
+                                    value={data.stats.accreditation}
+                                    onChange={(event) => setData('stats', { ...data.stats, accreditation: event.target.value })}
+                                    placeholder="Akreditasi"
+                                    className="rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
+                                />
+                                <input
+                                    value={data.stats.photos}
+                                    onChange={(event) => setData('stats', { ...data.stats, photos: event.target.value })}
+                                    placeholder="Dokumentasi"
+                                    className="rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
+                                />
+                            </div>
+                        </div>
+
+                        <div className="mt-6 grid gap-4 rounded-2xl border border-slate-200 bg-slate-50 p-4 dark:border-slate-600 dark:bg-slate-900">
+                            <div className="flex items-center justify-between">
+                                <h3 className="text-sm font-semibold text-slate-700 dark:text-slate-200">Berita Sorotan</h3>
+                                <label className="flex items-center gap-2 text-sm text-slate-600 dark:text-slate-300">
+                                    <input
+                                        type="checkbox"
+                                        checked={data.newsMode === 'manual'}
+                                        onChange={(event) => setData('newsMode', event.target.checked ? 'manual' : 'auto')}
+                                        className="h-4 w-4 rounded border-slate-300 text-slate-900 focus:ring-slate-500"
+                                    />
+                                    Gunakan pilihan manual
+                                </label>
+                            </div>
+                            {data.newsMode === 'manual' ? (
+                                <div className="grid gap-2">
+                                    {availableNews.length === 0 ? (
+                                        <p className="text-xs text-slate-500 dark:text-slate-400">Belum ada berita untuk dipilih.</p>
+                                    ) : (
+                                        availableNews.map((news) => (
+                                            <label key={news.id} className="flex items-center gap-2 text-sm text-slate-700 dark:text-slate-200">
+                                                <input
+                                                    type="checkbox"
+                                                    checked={data.pins.includes(news.id)}
+                                                    onChange={() => togglePin(news.id)}
+                                                    className="h-4 w-4 rounded border-slate-300 text-slate-900 focus:ring-slate-500"
+                                                />
+                                                {news.title}
+                                            </label>
+                                        ))
+                                    )}
+                                </div>
+                            ) : (
+                                <p className="text-xs text-slate-500 dark:text-slate-400">Mode otomatis akan menampilkan berita terbaru secara dinamis.</p>
+                            )}
+                        </div>
+
+                        <div className="mt-6 grid gap-4 rounded-2xl border border-slate-200 bg-slate-50 p-4 dark:border-slate-600 dark:bg-slate-900">
+                            <h3 className="text-sm font-semibold text-slate-700 dark:text-slate-200">Agenda &amp; Galeri</h3>
+                            <label className="block text-xs font-medium text-slate-500 dark:text-slate-300">Jumlah agenda yang tampil</label>
+                            <input
+                                type="number"
+                                min={1}
+                                value={data.agendaLimit}
+                                onChange={(event) => setData('agendaLimit', Number(event.target.value) || 1)}
+                                className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
+                            />
+                            <div className="grid gap-2">
+                                <label className="text-xs font-medium text-slate-500 dark:text-slate-300">Sumber galeri</label>
+                                <select
+                                    value={data.galleryMode}
+                                    onChange={(event) => setData('galleryMode', event.target.value as 'album' | 'manual')}
+                                    className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
+                                >
+                                    <option value="album">Gunakan album</option>
+                                    <option value="manual">Manual (ID media)</option>
+                                </select>
+                            </div>
+                            {data.galleryMode === 'album' ? (
+                                <select
+                                    value={data.galleryAlbumId}
+                                    onChange={(event) => setData('galleryAlbumId', event.target.value)}
+                                    className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
+                                >
+                                    <option value="">Pilih album</option>
+                                    {albums.map((album) => (
+                                        <option key={album.id} value={album.id}>
+                                            {album.name}
+                                        </option>
+                                    ))}
+                                </select>
+                            ) : (
+                                <textarea
+                                    value={data.galleryManual}
+                                    onChange={(event) => setData('galleryManual', event.target.value)}
+                                    rows={3}
+                                    placeholder="Masukkan ID media dipisahkan koma"
+                                    className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
+                                />
+                            )}
+                        </div>
+
+                        <div className="mt-6 space-y-4 rounded-2xl border border-slate-200 bg-slate-50 p-4 dark:border-slate-600 dark:bg-slate-900">
+                            <div className="flex items-center justify-between">
+                                <h3 className="text-sm font-semibold text-slate-700 dark:text-slate-200">Testimoni</h3>
+                                <label className="flex items-center gap-2 text-sm text-slate-600 dark:text-slate-300">
+                                    <input
+                                        type="checkbox"
+                                        checked={data.showTestimonials}
+                                        onChange={(event) => setData('showTestimonials', event.target.checked)}
+                                        className="h-4 w-4 rounded border-slate-300 text-slate-900 focus:ring-slate-500"
+                                    />
+                                    Tampilkan testimoni
+                                </label>
+                            </div>
+                            <div className="space-y-3">
+                                {data.testimonials.map((testimonial, index) => (
+                                    <div key={`testimonial-${index}`} className="grid gap-2 rounded-xl border border-slate-200 bg-white p-4 dark:border-slate-600 dark:bg-slate-800">
+                                        <div className="flex items-center justify-between">
+                                            <h4 className="text-sm font-semibold text-slate-700 dark:text-slate-200">Testimoni {index + 1}</h4>
+                                            <button
+                                                type="button"
+                                                onClick={() => removeTestimonial(index)}
+                                                className="text-xs font-semibold text-rose-500 hover:text-rose-400"
+                                            >
+                                                Hapus
+                                            </button>
+                                        </div>
+                                        <input
+                                            value={testimonial.name}
+                                            onChange={(event) => updateTestimonial(index, 'name', event.target.value)}
+                                            placeholder="Nama narasumber"
+                                            className="rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
+                                        />
+                                        <input
+                                            value={testimonial.role}
+                                            onChange={(event) => updateTestimonial(index, 'role', event.target.value)}
+                                            placeholder="Peran/relasi"
+                                            className="rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
+                                        />
+                                        <textarea
+                                            value={testimonial.quote}
+                                            onChange={(event) => updateTestimonial(index, 'quote', event.target.value)}
+                                            rows={3}
+                                            placeholder="Isi testimoni"
+                                            className="rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
+                                        />
+                                    </div>
+                                ))}
+                            </div>
+                            <button
+                                type="button"
+                                onClick={addTestimonial}
+                                className="rounded-lg border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-100 dark:border-slate-600 dark:text-slate-200"
+                            >
+                                Tambah Testimoni
+                            </button>
+                        </div>
+                    </section>
+                ) : null}
+
+                <div className="flex items-center justify-end gap-2">
+                    <a
+                        href="/admin/pages"
+                        className="rounded-xl border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:bg-slate-100 dark:border-slate-600 dark:bg-slate-800 dark:text-white"
+                    >
+                        Batal
+                    </a>
+                    <button
+                        type="submit"
+                        disabled={processing}
+                        className="rounded-xl bg-slate-900 px-5 py-2 text-sm font-semibold text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-slate-700 dark:hover:bg-slate-600"
+                    >
+                        {processing ? 'Menyimpan...' : 'Simpan'}
+                    </button>
+                </div>
+            </form>
+            {toastMessage ? <Toast message={toastMessage} /> : null}
+        </AdminLayout>
+    );
+}

--- a/resources/js/pages/admin/events/Form.tsx
+++ b/resources/js/pages/admin/events/Form.tsx
@@ -1,127 +1,354 @@
-import React, { useState } from 'react';
-import { router, usePage } from '@inertiajs/react';
+import { useEffect, useMemo, useState } from 'react';
+import { useForm, usePage } from '@inertiajs/react';
 import AdminLayout from '@/pages/admin/_layout/AdminLayout';
 
+type EventStatus = 'draft' | 'scheduled' | 'published' | 'archived';
+type EventRecurrence = 'once' | 'weekly' | 'monthly';
+
+type EventResource = {
+    id?: number;
+    title?: string;
+    slug?: string | null;
+    description?: string | null;
+    location?: string | null;
+    timezone?: string | null;
+    start_at?: string | null;
+    end_at?: string | null;
+    recurrence?: EventRecurrence | null;
+    registration_url?: string | null;
+    cover_url?: string | null;
+    cover_alt?: string | null;
+    status?: EventStatus | null;
+};
+
+type PageProps = {
+    errors?: Record<string, string>;
+    flash?: { success?: string };
+};
+
+type FormValues = {
+    title: string;
+    slug: string;
+    description: string;
+    location: string;
+    timezone: string;
+    start_at: string;
+    end_at: string;
+    recurrence: EventRecurrence;
+    registration_url: string;
+    status: EventStatus;
+    cover: File | null;
+    cover_alt: string;
+};
+
+const STATUS_OPTIONS: Array<{ value: EventStatus; label: string }> = [
+    { value: 'draft', label: 'Draft' },
+    { value: 'scheduled', label: 'Terjadwal' },
+    { value: 'published', label: 'Terbit' },
+    { value: 'archived', label: 'Arsip' },
+];
+
+const RECURRENCE_OPTIONS: Array<{ value: EventRecurrence; label: string }> = [
+    { value: 'once', label: 'Sekali' },
+    { value: 'weekly', label: 'Mingguan' },
+    { value: 'monthly', label: 'Bulanan' },
+];
+
+function Toast({ message }: { message: string }) {
+    return (
+        <div className="fixed bottom-6 right-6 z-50 rounded-xl bg-slate-900 px-4 py-3 text-sm font-semibold text-white shadow-xl dark:bg-emerald-500">
+            {message}
+        </div>
+    );
+}
+
 interface EventFormProps {
-    event?: {
-        id: number;
-        title: string;
-        slug: string;
-        description?: string | null;
-        start_at: string;
-        end_at?: string | null;
-        location?: string | null;
-    };
+    event?: EventResource;
 }
 
 export default function EventForm({ event }: EventFormProps) {
     const isEdit = Boolean(event?.id);
-    const { props } = usePage();
-    const errors = (props as any)?.errors as Record<string, string> | undefined;
+    const { props } = usePage<PageProps>();
+    const [coverPreview, setCoverPreview] = useState<string | null>(event?.cover_url ?? null);
+    const [toastMessage, setToastMessage] = useState<string | null>(props.flash?.success ?? null);
 
-    const [form, setForm] = useState({
+    const { data, setData, post, processing, errors, reset } = useForm<FormValues>({
         title: event?.title ?? '',
         slug: event?.slug ?? '',
         description: event?.description ?? '',
+        location: event?.location ?? '',
+        timezone: event?.timezone ?? 'Asia/Jakarta',
         start_at: event?.start_at ? event.start_at.slice(0, 16) : '',
         end_at: event?.end_at ? event.end_at.slice(0, 16) : '',
-        location: event?.location ?? '',
+        recurrence: event?.recurrence ?? 'once',
+        registration_url: event?.registration_url ?? '',
+        status: event?.status ?? 'draft',
+        cover: null,
+        cover_alt: event?.cover_alt ?? '',
     });
 
-    const submit = (e: React.FormEvent) => {
+    useEffect(() => {
+        if (props.flash?.success) {
+            setToastMessage(props.flash.success);
+            const timeout = setTimeout(() => setToastMessage(null), 3500);
+            return () => clearTimeout(timeout);
+        }
+
+        return undefined;
+    }, [props.flash?.success]);
+
+    useEffect(() => {
+        return () => {
+            if (coverPreview && coverPreview.startsWith('blob:')) {
+                URL.revokeObjectURL(coverPreview);
+            }
+        };
+    }, [coverPreview]);
+
+    const showToast = (message: string) => {
+        setToastMessage(message);
+        setTimeout(() => setToastMessage(null), 3500);
+    };
+
+    const handleCoverChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+        const file = event.target.files?.[0] ?? null;
+        setData('cover', file);
+
+        if (coverPreview && coverPreview.startsWith('blob:')) {
+            URL.revokeObjectURL(coverPreview);
+        }
+
+        setCoverPreview(file ? URL.createObjectURL(file) : event?.cover_url ?? null);
+    };
+
+    const submit = (e: React.FormEvent<HTMLFormElement>) => {
         e.preventDefault();
-        const payload = {
-            ...form,
-            start_at: form.start_at ? new Date(form.start_at).toISOString() : null,
-            end_at: form.end_at ? new Date(form.end_at).toISOString() : null,
+
+        const payload: Record<string, unknown> = {
+            ...data,
+            start_at: data.start_at ? new Date(data.start_at).toISOString() : null,
+            end_at: data.end_at ? new Date(data.end_at).toISOString() : null,
         };
 
-        if (isEdit && event) {
-            router.post(`/admin/events/${event.id}`, { ...payload, _method: 'put' });
-        } else {
-            router.post('/admin/events', payload);
+        if (!data.cover) {
+            delete payload.cover;
         }
+
+        if (isEdit && event?.id) {
+            payload._method = 'put';
+        }
+
+        post(isEdit && event?.id ? `/admin/events/${event.id}` : '/admin/events', {
+            data: payload,
+            forceFormData: true,
+            preserveScroll: true,
+            onSuccess: () => {
+                showToast(isEdit ? 'Agenda diperbarui.' : 'Agenda dibuat.');
+
+                if (!isEdit) {
+                    reset();
+                    setCoverPreview(null);
+                }
+            },
+        });
     };
+
+    const icsHref = useMemo(() => {
+        if (!event?.id) {
+            return null;
+        }
+
+        return `/events/${event.id}/ics`;
+    }, [event?.id]);
 
     return (
         <AdminLayout title={isEdit ? 'Edit Agenda' : 'Tambah Agenda'}>
-            <form onSubmit={submit} className="grid max-w-3xl gap-4">
-                <div>
-                    <label className="block text-sm font-medium text-slate-700">Judul</label>
-                    <input
-                        value={form.title}
-                        onChange={(e) => setForm({ ...form, title: e.target.value })}
-                        className="mt-1 w-full rounded-xl border border-slate-300 px-3 py-2 text-sm focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300"
-                        required
-                    />
-                    {errors?.title ? <p className="mt-1 text-xs text-rose-600">{errors.title}</p> : null}
-                </div>
-                <div>
-                    <label className="block text-sm font-medium text-slate-700">Slug (opsional)</label>
-                    <input
-                        value={form.slug}
-                        onChange={(e) => setForm({ ...form, slug: e.target.value })}
-                        className="mt-1 w-full rounded-xl border border-slate-300 px-3 py-2 text-sm focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300"
-                    />
-                    {errors?.slug ? <p className="mt-1 text-xs text-rose-600">{errors.slug}</p> : null}
-                </div>
-                <div className="grid gap-4 md:grid-cols-2">
-                    <div>
-                        <label className="block text-sm font-medium text-slate-700">Mulai</label>
-                        <input
-                            type="datetime-local"
-                            value={form.start_at}
-                            onChange={(e) => setForm({ ...form, start_at: e.target.value })}
-                            className="mt-1 w-full rounded-xl border border-slate-300 px-3 py-2 text-sm focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300"
-                            required
-                        />
-                        {errors?.start_at ? <p className="mt-1 text-xs text-rose-600">{errors.start_at}</p> : null}
+            <form onSubmit={submit} className="mx-auto flex w-full max-w-3xl flex-col gap-6" encType="multipart/form-data">
+                <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-800">
+                    <div className="mb-6 flex flex-col gap-2">
+                        <h2 className="text-lg font-semibold text-slate-900 dark:text-white">Informasi Agenda</h2>
+                        <p className="text-sm text-slate-500 dark:text-slate-400">Atur judul, jadwal, dan lokasi agenda publik sekolah.</p>
                     </div>
-                    <div>
-                        <label className="block text-sm font-medium text-slate-700">Selesai</label>
-                        <input
-                            type="datetime-local"
-                            value={form.end_at}
-                            onChange={(e) => setForm({ ...form, end_at: e.target.value })}
-                            className="mt-1 w-full rounded-xl border border-slate-300 px-3 py-2 text-sm focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300"
-                        />
-                        {errors?.end_at ? <p className="mt-1 text-xs text-rose-600">{errors.end_at}</p> : null}
+                    <div className="grid gap-4 md:grid-cols-2">
+                        <div className="md:col-span-2">
+                            <label className="block text-sm font-medium text-slate-700 dark:text-slate-300">Judul Agenda</label>
+                            <input
+                                value={data.title}
+                                onChange={(event) => setData('title', event.target.value)}
+                                className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
+                                required
+                            />
+                            {errors.title ? <p className="mt-1 text-xs text-rose-500">{errors.title}</p> : null}
+                        </div>
+                        <div>
+                            <label className="block text-sm font-medium text-slate-700 dark:text-slate-300">Slug</label>
+                            <input
+                                value={data.slug}
+                                onChange={(event) => setData('slug', event.target.value)}
+                                placeholder="agenda-inklusif"
+                                className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
+                            />
+                            {errors.slug ? <p className="mt-1 text-xs text-rose-500">{errors.slug}</p> : null}
+                        </div>
+                        <div>
+                            <label className="block text-sm font-medium text-slate-700 dark:text-slate-300">Zona Waktu</label>
+                            <input
+                                value={data.timezone}
+                                onChange={(event) => setData('timezone', event.target.value)}
+                                placeholder="Asia/Jakarta"
+                                className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
+                            />
+                            {errors.timezone ? <p className="mt-1 text-xs text-rose-500">{errors.timezone}</p> : null}
+                        </div>
+                        <div>
+                            <label className="block text-sm font-medium text-slate-700 dark:text-slate-300">Status</label>
+                            <select
+                                value={data.status}
+                                onChange={(event) => setData('status', event.target.value as EventStatus)}
+                                className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
+                            >
+                                {STATUS_OPTIONS.map((option) => (
+                                    <option key={option.value} value={option.value}>
+                                        {option.label}
+                                    </option>
+                                ))}
+                            </select>
+                            {errors.status ? <p className="mt-1 text-xs text-rose-500">{errors.status}</p> : null}
+                        </div>
+                        <div>
+                            <label className="block text-sm font-medium text-slate-700 dark:text-slate-300">Mulai</label>
+                            <input
+                                type="datetime-local"
+                                value={data.start_at}
+                                onChange={(event) => setData('start_at', event.target.value)}
+                                className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
+                                required
+                            />
+                            {errors.start_at ? <p className="mt-1 text-xs text-rose-500">{errors.start_at}</p> : null}
+                        </div>
+                        <div>
+                            <label className="block text-sm font-medium text-slate-700 dark:text-slate-300">Selesai</label>
+                            <input
+                                type="datetime-local"
+                                value={data.end_at}
+                                onChange={(event) => setData('end_at', event.target.value)}
+                                className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
+                            />
+                            {errors.end_at ? <p className="mt-1 text-xs text-rose-500">{errors.end_at}</p> : null}
+                        </div>
+                        <div>
+                            <label className="block text-sm font-medium text-slate-700 dark:text-slate-300">Lokasi</label>
+                            <input
+                                value={data.location}
+                                onChange={(event) => setData('location', event.target.value)}
+                                placeholder="Aula inklusi sekolah"
+                                className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
+                            />
+                            {errors.location ? <p className="mt-1 text-xs text-rose-500">{errors.location}</p> : null}
+                        </div>
+                        <div>
+                            <label className="block text-sm font-medium text-slate-700 dark:text-slate-300">Frekuensi</label>
+                            <select
+                                value={data.recurrence}
+                                onChange={(event) => setData('recurrence', event.target.value as EventRecurrence)}
+                                className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
+                            >
+                                {RECURRENCE_OPTIONS.map((option) => (
+                                    <option key={option.value} value={option.value}>
+                                        {option.label}
+                                    </option>
+                                ))}
+                            </select>
+                            {errors.recurrence ? <p className="mt-1 text-xs text-rose-500">{errors.recurrence}</p> : null}
+                        </div>
+                        <div className="md:col-span-2">
+                            <label className="block text-sm font-medium text-slate-700 dark:text-slate-300">URL Pendaftaran</label>
+                            <input
+                                value={data.registration_url}
+                                onChange={(event) => setData('registration_url', event.target.value)}
+                                placeholder="https://..."
+                                className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
+                            />
+                            {errors.registration_url ? <p className="mt-1 text-xs text-rose-500">{errors.registration_url}</p> : null}
+                        </div>
+                        <div className="md:col-span-2">
+                            <label className="block text-sm font-medium text-slate-700 dark:text-slate-300">Deskripsi</label>
+                            <textarea
+                                value={data.description}
+                                onChange={(event) => setData('description', event.target.value)}
+                                rows={8}
+                                className="mt-1 w-full rounded-2xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
+                            />
+                            {errors.description ? <p className="mt-1 text-xs text-rose-500">{errors.description}</p> : null}
+                        </div>
                     </div>
-                </div>
-                <div>
-                    <label className="block text-sm font-medium text-slate-700">Lokasi</label>
-                    <input
-                        value={form.location}
-                        onChange={(e) => setForm({ ...form, location: e.target.value })}
-                        className="mt-1 w-full rounded-xl border border-slate-300 px-3 py-2 text-sm focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300"
-                    />
-                    {errors?.location ? <p className="mt-1 text-xs text-rose-600">{errors.location}</p> : null}
-                </div>
-                <div>
-                    <label className="block text-sm font-medium text-slate-700">Deskripsi</label>
-                    <textarea
-                        value={form.description}
-                        onChange={(e) => setForm({ ...form, description: e.target.value })}
-                        className="mt-1 w-full rounded-xl border border-slate-300 px-3 py-2 text-sm focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300"
-                        rows={8}
-                    />
-                    {errors?.description ? <p className="mt-1 text-xs text-rose-600">{errors.description}</p> : null}
-                </div>
+                </section>
+
+                <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-800">
+                    <div className="mb-4 flex items-center justify-between">
+                        <div>
+                            <h2 className="text-lg font-semibold text-slate-900 dark:text-white">Cover Agenda</h2>
+                            <p className="text-sm text-slate-500 dark:text-slate-400">Unggah cover 16:9 minimal 1200x675 piksel untuk memperkuat narasi agenda.</p>
+                        </div>
+                        {icsHref ? (
+                            <a
+                                href={icsHref}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="rounded-xl border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-700 transition hover:bg-slate-100 dark:border-slate-600 dark:text-white"
+                            >
+                                Unduh ICS
+                            </a>
+                        ) : null}
+                    </div>
+                    <div className="grid gap-4 md:grid-cols-[minmax(0,320px)_1fr]">
+                        <div className="flex flex-col gap-3">
+                            <label className="block text-sm font-medium text-slate-700 dark:text-slate-300" htmlFor="cover">
+                                Pilih berkas cover
+                            </label>
+                            <input
+                                id="cover"
+                                type="file"
+                                accept="image/jpeg,image/png,image/webp"
+                                onChange={handleCoverChange}
+                                className="block w-full rounded-xl border border-dashed border-slate-300 bg-slate-50 px-3 py-2 text-sm text-slate-600 file:mr-4 file:rounded-lg file:border-0 file:bg-slate-900 file:px-4 file:py-2 file:text-sm file:font-semibold file:text-white hover:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-300 dark:file:bg-slate-700"
+                            />
+                            {errors.cover ? <p className="text-xs text-rose-500">{errors.cover}</p> : null}
+                            <input
+                                value={data.cover_alt}
+                                onChange={(event) => setData('cover_alt', event.target.value)}
+                                placeholder="Deskripsi singkat gambar"
+                                className="w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
+                            />
+                            {errors.cover_alt ? <p className="text-xs text-rose-500">{errors.cover_alt}</p> : null}
+                        </div>
+                        <div className="flex items-center justify-center rounded-2xl border border-slate-200 bg-slate-50 p-4 dark:border-slate-600 dark:bg-slate-900">
+                            {coverPreview ? (
+                                <img src={coverPreview} alt="Preview cover agenda" className="h-48 w-full rounded-xl object-cover" />
+                            ) : (
+                                <p className="text-sm text-slate-500 dark:text-slate-400">Belum ada pratinjau cover.</p>
+                            )}
+                        </div>
+                    </div>
+                </section>
+
                 <div className="flex items-center justify-end gap-2">
                     <a
                         href="/admin/events"
-                        className="rounded-xl border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-100"
+                        className="rounded-xl border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:bg-slate-100 dark:border-slate-600 dark:bg-slate-800 dark:text-white"
                     >
-                        Kembali
+                        Batal
                     </a>
                     <button
                         type="submit"
-                        className="rounded-xl bg-slate-900 px-5 py-2 text-sm font-semibold text-white hover:bg-slate-800"
+                        disabled={processing}
+                        className="rounded-xl bg-slate-900 px-5 py-2 text-sm font-semibold text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-slate-700 dark:hover:bg-slate-600"
                     >
-                        Simpan
+                        {processing ? 'Menyimpan...' : 'Simpan'}
                     </button>
                 </div>
             </form>
+            {toastMessage ? <Toast message={toastMessage} /> : null}
         </AdminLayout>
     );
 }

--- a/resources/js/pages/admin/posts/Form.tsx
+++ b/resources/js/pages/admin/posts/Form.tsx
@@ -1,141 +1,463 @@
-import React, { useState } from 'react';
-import { router, usePage } from '@inertiajs/react';
+import { useEffect, useMemo, useState } from 'react';
+import { useForm, usePage } from '@inertiajs/react';
 import AdminLayout from '@/pages/admin/_layout/AdminLayout';
 
+interface PostResource {
+    id?: number;
+    title?: string;
+    slug?: string | null;
+    excerpt?: string | null;
+    content?: string | null;
+    cover_url?: string | null;
+    cover_alt?: string | null;
+    category?: string | null;
+    tags?: string[] | null;
+    sticky?: boolean | null;
+    status?: 'draft' | 'scheduled' | 'published' | 'archived';
+    published_at?: string | null;
+    seo_title?: string | null;
+    seo_description?: string | null;
+    seo_keywords?: string | null;
+}
+
 interface PostFormProps {
-    post?: {
-        id: number;
-        title: string;
-        slug: string;
-        excerpt?: string | null;
-        content?: string | null;
-        cover_url?: string | null;
-        status: 'draft' | 'published';
-        published_at?: string | null;
-    };
+    post?: PostResource;
+}
+
+type PageProps = {
+    errors?: Record<string, string>;
+    flash?: { success?: string };
+    categories?: string[];
+    tags?: string[];
+};
+
+type FormValues = {
+    title: string;
+    slug: string;
+    excerpt: string;
+    body: string;
+    category: string;
+    tags: string[];
+    sticky: boolean;
+    status: 'draft' | 'scheduled' | 'published' | 'archived';
+    published_at: string;
+    cover: File | null;
+    cover_alt: string;
+    seo_title: string;
+    seo_description: string;
+    seo_keywords: string;
+};
+
+const STATUS_OPTIONS: Array<{ value: FormValues['status']; label: string }> = [
+    { value: 'draft', label: 'Draft' },
+    { value: 'scheduled', label: 'Terjadwal' },
+    { value: 'published', label: 'Publikasi' },
+    { value: 'archived', label: 'Arsip' },
+];
+
+function Toast({ message }: { message: string }) {
+    return (
+        <div className="fixed bottom-6 right-6 z-50 rounded-xl bg-slate-900 px-4 py-3 text-sm font-semibold text-white shadow-xl dark:bg-emerald-500">
+            {message}
+        </div>
+    );
 }
 
 export default function PostForm({ post }: PostFormProps) {
     const isEdit = Boolean(post?.id);
-    const { props } = usePage();
-    const [form, setForm] = useState({
+    const { props } = usePage<PageProps>();
+    const categories = useMemo(() => props.categories ?? [], [props.categories]);
+    const suggestedTags = useMemo(() => props.tags ?? [], [props.tags]);
+
+    const [coverPreview, setCoverPreview] = useState<string | null>(post?.cover_url ?? null);
+    const [toastMessage, setToastMessage] = useState<string | null>(props.flash?.success ?? null);
+    const [tagInput, setTagInput] = useState('');
+
+    const { data, setData, post: postForm, processing, errors, reset } = useForm<FormValues>({
         title: post?.title ?? '',
         slug: post?.slug ?? '',
         excerpt: post?.excerpt ?? '',
-        content: post?.content ?? '',
-        cover_url: post?.cover_url ?? '',
+        body: post?.content ?? '',
+        category: post?.category ?? '',
+        tags: post?.tags ?? [],
+        sticky: Boolean(post?.sticky ?? false),
         status: post?.status ?? 'draft',
         published_at: post?.published_at ? post.published_at.slice(0, 16) : '',
+        cover: null,
+        cover_alt: post?.cover_alt ?? '',
+        seo_title: post?.seo_title ?? '',
+        seo_description: post?.seo_description ?? '',
+        seo_keywords: post?.seo_keywords ?? '',
     });
 
-    const errors = (props as any)?.errors as Record<string, string> | undefined;
+    useEffect(() => {
+        if (props.flash?.success) {
+            setToastMessage(props.flash.success);
+            const timeout = setTimeout(() => setToastMessage(null), 3500);
+            return () => clearTimeout(timeout);
+        }
 
-    const submit = (e: React.FormEvent) => {
-        e.preventDefault();
-        const payload = {
-            ...form,
-            published_at: form.published_at ? new Date(form.published_at).toISOString() : null,
+        return undefined;
+    }, [props.flash?.success]);
+
+    useEffect(() => {
+        return () => {
+            if (coverPreview && coverPreview.startsWith('blob:')) {
+                URL.revokeObjectURL(coverPreview);
+            }
+        };
+    }, [coverPreview]);
+
+    const addTagFromInput = () => {
+        const value = tagInput.trim();
+
+        if (!value) {
+            return;
+        }
+
+        if (!data.tags.includes(value)) {
+            setData('tags', [...data.tags, value]);
+        }
+
+        setTagInput('');
+    };
+
+    const removeTag = (tag: string) => {
+        setData(
+            'tags',
+            data.tags.filter((item) => item !== tag),
+        );
+    };
+
+    const handleCoverChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+        const file = event.target.files?.[0] ?? null;
+
+        setData('cover', file);
+
+        if (coverPreview && coverPreview.startsWith('blob:')) {
+            URL.revokeObjectURL(coverPreview);
+        }
+
+        setCoverPreview(file ? URL.createObjectURL(file) : post?.cover_url ?? null);
+    };
+
+    const showToast = (message: string) => {
+        setToastMessage(message);
+        setTimeout(() => setToastMessage(null), 3500);
+    };
+
+    const submit = (event: React.FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+
+        const payload: Record<string, unknown> = {
+            ...data,
+            sticky: data.sticky ? 1 : 0,
+            tags: data.tags,
+            published_at: data.published_at ? new Date(data.published_at).toISOString() : null,
         };
 
-        if (isEdit && post) {
-            router.post(`/admin/posts/${post.id}`, { ...payload, _method: 'put' });
-        } else {
-            router.post('/admin/posts', payload);
+        if (!data.cover) {
+            delete payload.cover;
         }
+
+        if (!data.cover_alt) {
+            payload.cover_alt = '';
+        }
+
+        if (!data.seo_keywords) {
+            payload.seo_keywords = '';
+        }
+
+        if (isEdit && post?.id) {
+            payload._method = 'put';
+        }
+
+        postForm(isEdit && post?.id ? `/admin/posts/${post.id}` : '/admin/posts', {
+            data: payload,
+            forceFormData: true,
+            preserveScroll: true,
+            onSuccess: () => {
+                showToast(isEdit ? 'Berita diperbarui.' : 'Berita dibuat.');
+
+                if (!isEdit) {
+                    reset();
+                    setCoverPreview(null);
+                }
+            },
+        });
     };
 
     return (
         <AdminLayout title={isEdit ? 'Edit Berita' : 'Tambah Berita'}>
-            <form onSubmit={submit} className="grid max-w-4xl gap-4">
-                <div>
-                    <label className="block text-sm font-medium text-slate-700">Judul</label>
-                    <input
-                        value={form.title}
-                        onChange={(e) => setForm({ ...form, title: e.target.value })}
-                        className="mt-1 w-full rounded-xl border border-slate-300 px-3 py-2 text-sm focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300"
-                        required
-                    />
-                    {errors?.title ? <p className="mt-1 text-xs text-rose-600">{errors.title}</p> : null}
-                </div>
-                <div>
-                    <label className="block text-sm font-medium text-slate-700">Slug (opsional)</label>
-                    <input
-                        value={form.slug}
-                        onChange={(e) => setForm({ ...form, slug: e.target.value })}
-                        className="mt-1 w-full rounded-xl border border-slate-300 px-3 py-2 text-sm focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300"
-                    />
-                    {errors?.slug ? <p className="mt-1 text-xs text-rose-600">{errors.slug}</p> : null}
-                </div>
-                <div className="grid gap-4 md:grid-cols-2">
-                    <div>
-                        <label className="block text-sm font-medium text-slate-700">Status</label>
-                        <select
-                            value={form.status}
-                            onChange={(e) => setForm({ ...form, status: e.target.value as 'draft' | 'published' })}
-                            className="mt-1 w-full rounded-xl border border-slate-300 px-3 py-2 text-sm focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300"
-                        >
-                            <option value="draft">Draft</option>
-                            <option value="published">Published</option>
-                        </select>
-                        {errors?.status ? <p className="mt-1 text-xs text-rose-600">{errors.status}</p> : null}
+            <form onSubmit={submit} className="mx-auto flex w-full max-w-4xl flex-col gap-6" encType="multipart/form-data">
+                <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-800">
+                    <div className="mb-6 flex flex-col gap-2">
+                        <h2 className="text-lg font-semibold text-slate-900 dark:text-white">Informasi Utama</h2>
+                        <p className="text-sm text-slate-500 dark:text-slate-400">
+                            Tulis judul, slug, dan ringkasan untuk berita. Ringkasan membantu pembaca memahami konteks sebelum membaca konten lengkap.
+                        </p>
                     </div>
-                    <div>
-                        <label className="block text-sm font-medium text-slate-700">Tanggal Publikasi</label>
-                        <input
-                            type="datetime-local"
-                            value={form.published_at}
-                            onChange={(e) => setForm({ ...form, published_at: e.target.value })}
-                            className="mt-1 w-full rounded-xl border border-slate-300 px-3 py-2 text-sm focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300"
-                        />
-                        {errors?.published_at ? <p className="mt-1 text-xs text-rose-600">{errors.published_at}</p> : null}
+                    <div className="grid gap-4 md:grid-cols-2">
+                        <div className="md:col-span-2">
+                            <label className="block text-sm font-medium text-slate-700 dark:text-slate-300">Judul</label>
+                            <input
+                                value={data.title}
+                                onChange={(event) => setData('title', event.target.value)}
+                                className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
+                                required
+                            />
+                            {errors.title ? <p className="mt-1 text-xs text-rose-500">{errors.title}</p> : null}
+                        </div>
+                        <div>
+                            <label className="block text-sm font-medium text-slate-700 dark:text-slate-300">Slug</label>
+                            <input
+                                value={data.slug}
+                                onChange={(event) => setData('slug', event.target.value)}
+                                className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
+                                placeholder="judul-berita-baru"
+                            />
+                            {errors.slug ? <p className="mt-1 text-xs text-rose-500">{errors.slug}</p> : null}
+                        </div>
+                        <div>
+                            <label className="block text-sm font-medium text-slate-700 dark:text-slate-300">Kategori</label>
+                            <select
+                                value={data.category}
+                                onChange={(event) => setData('category', event.target.value)}
+                                className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
+                            >
+                                <option value="">Pilih kategori</option>
+                                {categories.map((category) => (
+                                    <option key={category} value={category}>
+                                        {category}
+                                    </option>
+                                ))}
+                            </select>
+                            {errors.category ? <p className="mt-1 text-xs text-rose-500">{errors.category}</p> : null}
+                        </div>
+                        <div>
+                            <label className="block text-sm font-medium text-slate-700 dark:text-slate-300">Status</label>
+                            <select
+                                value={data.status}
+                                onChange={(event) => setData('status', event.target.value as FormValues['status'])}
+                                className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
+                            >
+                                {STATUS_OPTIONS.map((option) => (
+                                    <option key={option.value} value={option.value}>
+                                        {option.label}
+                                    </option>
+                                ))}
+                            </select>
+                            {errors.status ? <p className="mt-1 text-xs text-rose-500">{errors.status}</p> : null}
+                        </div>
+                        <div>
+                            <label className="block text-sm font-medium text-slate-700 dark:text-slate-300">Jadwalkan Publikasi</label>
+                            <input
+                                type="datetime-local"
+                                value={data.published_at}
+                                onChange={(event) => setData('published_at', event.target.value)}
+                                className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
+                            />
+                            {errors.published_at ? <p className="mt-1 text-xs text-rose-500">{errors.published_at}</p> : null}
+                        </div>
+                        <label className="flex items-center gap-2 text-sm font-medium text-slate-700 dark:text-slate-300 md:col-span-2">
+                            <input
+                                type="checkbox"
+                                checked={data.sticky}
+                                onChange={(event) => setData('sticky', event.target.checked)}
+                                className="h-4 w-4 rounded border-slate-300 text-slate-900 focus:ring-slate-500"
+                            />
+                            Jadikan berita sorotan utama
+                        </label>
+                        <div className="md:col-span-2">
+                            <label className="block text-sm font-medium text-slate-700 dark:text-slate-300">Ringkasan (140-200 karakter)</label>
+                            <textarea
+                                value={data.excerpt}
+                                onChange={(event) => setData('excerpt', event.target.value)}
+                                rows={4}
+                                className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
+                            />
+                            <div className="mt-1 flex items-center justify-between text-xs text-slate-500 dark:text-slate-400">
+                                <span>{data.excerpt.length} karakter</span>
+                                {errors.excerpt ? <span className="text-rose-500">{errors.excerpt}</span> : null}
+                            </div>
+                        </div>
                     </div>
-                </div>
-                <div>
-                    <label className="block text-sm font-medium text-slate-700">Cover URL</label>
-                    <input
-                        value={form.cover_url}
-                        onChange={(e) => setForm({ ...form, cover_url: e.target.value })}
-                        className="mt-1 w-full rounded-xl border border-slate-300 px-3 py-2 text-sm focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300"
-                        placeholder="https://..."
-                    />
-                    {errors?.cover_url ? <p className="mt-1 text-xs text-rose-600">{errors.cover_url}</p> : null}
-                </div>
-                <div>
-                    <label className="block text-sm font-medium text-slate-700">Ringkasan</label>
+                </section>
+
+                <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-800">
+                    <div className="mb-4 flex items-center justify-between gap-4">
+                        <div>
+                            <h2 className="text-lg font-semibold text-slate-900 dark:text-white">Cover Berita</h2>
+                            <p className="text-sm text-slate-500 dark:text-slate-400">Unggah cover rasio 16:9 minimal 1200x675 piksel.</p>
+                        </div>
+                    </div>
+                    <div className="grid gap-4 md:grid-cols-[minmax(0,320px)_1fr]">
+                        <div className="flex flex-col gap-3">
+                            <label className="block text-sm font-medium text-slate-700 dark:text-slate-300" htmlFor="cover">
+                                Pilih berkas cover
+                            </label>
+                            <input
+                                id="cover"
+                                type="file"
+                                accept="image/jpeg,image/png,image/webp"
+                                onChange={handleCoverChange}
+                                className="block w-full rounded-xl border border-dashed border-slate-300 bg-slate-50 px-3 py-2 text-sm text-slate-600 file:mr-4 file:rounded-lg file:border-0 file:bg-slate-900 file:px-4 file:py-2 file:text-sm file:font-semibold file:text-white hover:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-300 dark:file:bg-slate-700"
+                            />
+                            {errors.cover ? <p className="text-xs text-rose-500">{errors.cover}</p> : null}
+                            <input
+                                value={data.cover_alt}
+                                onChange={(event) => setData('cover_alt', event.target.value)}
+                                placeholder="Teks alternatif untuk aksesibilitas"
+                                className="w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
+                            />
+                            {errors.cover_alt ? <p className="text-xs text-rose-500">{errors.cover_alt}</p> : null}
+                        </div>
+                        <div className="flex items-center justify-center rounded-2xl border border-slate-200 bg-slate-50 p-4 dark:border-slate-600 dark:bg-slate-900">
+                            {coverPreview ? (
+                                <img src={coverPreview} alt="Preview cover" className="h-48 w-full rounded-xl object-cover" />
+                            ) : (
+                                <p className="text-sm text-slate-500 dark:text-slate-400">Belum ada pratinjau cover.</p>
+                            )}
+                        </div>
+                    </div>
+                </section>
+
+                <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-800">
+                    <h2 className="mb-4 text-lg font-semibold text-slate-900 dark:text-white">Isi Berita</h2>
                     <textarea
-                        value={form.excerpt}
-                        onChange={(e) => setForm({ ...form, excerpt: e.target.value })}
-                        className="mt-1 w-full rounded-xl border border-slate-300 px-3 py-2 text-sm focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300"
-                        rows={3}
+                        value={data.body}
+                        onChange={(event) => setData('body', event.target.value)}
+                        rows={14}
+                        className="w-full rounded-2xl border border-slate-300 bg-white px-3 py-2 text-sm leading-relaxed text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
+                        placeholder="Tulis konten berita di sini."
                     />
-                    {errors?.excerpt ? <p className="mt-1 text-xs text-rose-600">{errors.excerpt}</p> : null}
-                </div>
-                <div>
-                    <label className="block text-sm font-medium text-slate-700">Konten</label>
-                    <textarea
-                        value={form.content}
-                        onChange={(e) => setForm({ ...form, content: e.target.value })}
-                        className="mt-1 w-full rounded-xl border border-slate-300 px-3 py-2 text-sm focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300"
-                        rows={12}
-                    />
-                    {errors?.content ? <p className="mt-1 text-xs text-rose-600">{errors.content}</p> : null}
-                </div>
+                    {errors.body ? <p className="mt-1 text-xs text-rose-500">{errors.body}</p> : null}
+                </section>
+
+                <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-800">
+                    <div className="mb-4 flex flex-col gap-2">
+                        <h2 className="text-lg font-semibold text-slate-900 dark:text-white">Tag &amp; Optimasi</h2>
+                        <p className="text-sm text-slate-500 dark:text-slate-400">
+                            Gunakan tag untuk mengelompokkan berita dan optimalkan metadata untuk mesin pencari.
+                        </p>
+                    </div>
+                    <div className="grid gap-4 md:grid-cols-2">
+                        <div>
+                            <label className="block text-sm font-medium text-slate-700 dark:text-slate-300">Tambahkan Tag</label>
+                            <div className="mt-1 flex gap-2">
+                                <input
+                                    value={tagInput}
+                                    onChange={(event) => setTagInput(event.target.value)}
+                                    onKeyDown={(event) => {
+                                        if (event.key === 'Enter') {
+                                            event.preventDefault();
+                                            addTagFromInput();
+                                        }
+                                    }}
+                                    className="flex-1 rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
+                                    placeholder="Tekan Enter untuk menambahkan"
+                                />
+                                <button
+                                    type="button"
+                                    onClick={addTagFromInput}
+                                    className="rounded-xl bg-slate-900 px-4 py-2 text-sm font-semibold text-white hover:bg-slate-800 dark:bg-slate-700 dark:hover:bg-slate-600"
+                                >
+                                    Tambah
+                                </button>
+                            </div>
+                            {errors.tags ? <p className="mt-1 text-xs text-rose-500">{errors.tags}</p> : null}
+                            {data.tags.length > 0 ? (
+                                <div className="mt-3 flex flex-wrap gap-2">
+                                    {data.tags.map((tag) => (
+                                        <span
+                                            key={tag}
+                                            className="inline-flex items-center gap-2 rounded-full bg-slate-200 px-3 py-1 text-xs font-medium text-slate-700 dark:bg-slate-600 dark:text-white"
+                                        >
+                                            {tag}
+                                            <button
+                                                type="button"
+                                                onClick={() => removeTag(tag)}
+                                                className="text-slate-500 hover:text-rose-500"
+                                            >
+                                                ×
+                                            </button>
+                                        </span>
+                                    ))}
+                                </div>
+                            ) : null}
+                            {suggestedTags.length > 0 ? (
+                                <div className="mt-4 text-xs text-slate-500 dark:text-slate-400">
+                                    <p className="font-medium">Saran tag populer:</p>
+                                    <div className="mt-2 flex flex-wrap gap-2">
+                                        {suggestedTags.map((tag) => (
+                                            <button
+                                                type="button"
+                                                key={tag}
+                                                onClick={() => {
+                                                    if (!data.tags.includes(tag)) {
+                                                        setData('tags', [...data.tags, tag]);
+                                                    }
+                                                }}
+                                                className="rounded-full border border-slate-300 px-3 py-1 text-xs text-slate-600 hover:bg-slate-100 dark:border-slate-500 dark:text-slate-300 dark:hover:bg-slate-700"
+                                            >
+                                                {tag}
+                                            </button>
+                                        ))}
+                                    </div>
+                                </div>
+                            ) : null}
+                        </div>
+                        <div className="space-y-4">
+                            <div>
+                                <label className="block text-sm font-medium text-slate-700 dark:text-slate-300">Judul SEO</label>
+                                <input
+                                    value={data.seo_title}
+                                    onChange={(event) => setData('seo_title', event.target.value)}
+                                    className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
+                                />
+                                {errors.seo_title ? <p className="mt-1 text-xs text-rose-500">{errors.seo_title}</p> : null}
+                            </div>
+                            <div>
+                                <label className="block text-sm font-medium text-slate-700 dark:text-slate-300">Deskripsi SEO</label>
+                                <textarea
+                                    value={data.seo_description}
+                                    onChange={(event) => setData('seo_description', event.target.value)}
+                                    rows={3}
+                                    className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
+                                />
+                                {errors.seo_description ? <p className="mt-1 text-xs text-rose-500">{errors.seo_description}</p> : null}
+                            </div>
+                            <div>
+                                <label className="block text-sm font-medium text-slate-700 dark:text-slate-300">Kata Kunci SEO</label>
+                                <input
+                                    value={data.seo_keywords}
+                                    onChange={(event) => setData('seo_keywords', event.target.value)}
+                                    placeholder="Pisahkan dengan koma"
+                                    className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
+                                />
+                                {errors.seo_keywords ? <p className="mt-1 text-xs text-rose-500">{errors.seo_keywords}</p> : null}
+                            </div>
+                        </div>
+                    </div>
+                </section>
+
                 <div className="flex items-center justify-end gap-2">
                     <a
                         href="/admin/posts"
-                        className="rounded-xl border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-100"
+                        className="rounded-xl border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:bg-slate-100 dark:border-slate-600 dark:bg-slate-800 dark:text-white"
                     >
-                        Kembali
+                        Batal
                     </a>
                     <button
                         type="submit"
-                        className="rounded-xl bg-slate-900 px-5 py-2 text-sm font-semibold text-white hover:bg-slate-800"
+                        disabled={processing}
+                        className="rounded-xl bg-slate-900 px-5 py-2 text-sm font-semibold text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-slate-700 dark:hover:bg-slate-600"
                     >
-                        Simpan
+                        {processing ? 'Menyimpan...' : 'Simpan' }
                     </button>
                 </div>
             </form>
+            {toastMessage ? <Toast message={toastMessage} /> : null}
         </AdminLayout>
     );
 }
-

--- a/resources/js/pages/admin/settings/General.tsx
+++ b/resources/js/pages/admin/settings/General.tsx
@@ -1,83 +1,438 @@
-import React, { useState } from 'react';
-import { router } from '@inertiajs/react';
+import { useEffect, useState } from 'react';
+import { useForm, usePage } from '@inertiajs/react';
 import AdminLayout from '@/pages/admin/_layout/AdminLayout';
 
+type SocialLink = {
+    label: string;
+    url: string;
+};
+
+type FooterHour = {
+    day: string;
+    time: string;
+};
+
+type SettingsResource = {
+    site_name?: string;
+    tagline?: string | null;
+    address?: string | null;
+    phone?: string | null;
+    whatsapp?: string | null;
+    email?: string | null;
+    social?: SocialLink[] | null;
+    footer_hours?: FooterHour[] | null;
+    logo_url?: string | null;
+    og_image_url?: string | null;
+};
+
+type PageProps = {
+    flash?: { success?: string };
+};
+
+type FormValues = {
+    site_name: string;
+    tagline: string;
+    address: string;
+    phone: string;
+    whatsapp: string;
+    email: string;
+    social: SocialLink[];
+    footer_hours: FooterHour[];
+    logo: File | null;
+    og_image: File | null;
+};
+
+const ensureEntries = <T extends { [key: string]: string }>(items?: T[] | null, fallback: T = { label: '', url: '' } as T): T[] => {
+    if (!items || items.length === 0) {
+        return [fallback];
+    }
+
+    return items;
+};
+
+const ensureHours = (items?: FooterHour[] | null): FooterHour[] => {
+    if (!items || items.length === 0) {
+        return [{ day: '', time: '' }];
+    }
+
+    return items;
+};
+
+function Toast({ message }: { message: string }) {
+    return (
+        <div className="fixed bottom-6 right-6 z-50 rounded-xl bg-slate-900 px-4 py-3 text-sm font-semibold text-white shadow-xl dark:bg-emerald-500">
+            {message}
+        </div>
+    );
+}
+
 type SettingsProps = {
-    settings?: {
-        site_name?: string;
-        tagline?: string;
-        address?: string;
-        phone?: string;
-        fax?: string;
-        email?: string;
-        logo_path?: string;
-    } | null;
+    settings?: SettingsResource | null;
 };
 
 export default function SettingsGeneral({ settings }: SettingsProps) {
-    const [data, setData] = useState({
+    const { props } = usePage<PageProps>();
+    const [toastMessage, setToastMessage] = useState<string | null>(props.flash?.success ?? null);
+    const [logoPreview, setLogoPreview] = useState<string | null>(settings?.logo_url ?? null);
+    const [ogPreview, setOgPreview] = useState<string | null>(settings?.og_image_url ?? null);
+
+    const { data, setData, post, processing, errors, reset } = useForm<FormValues>({
         site_name: settings?.site_name ?? '',
         tagline: settings?.tagline ?? '',
         address: settings?.address ?? '',
         phone: settings?.phone ?? '',
-        fax: settings?.fax ?? '',
+        whatsapp: settings?.whatsapp ?? '',
         email: settings?.email ?? '',
-        logo_path: settings?.logo_path ?? '',
+        social: ensureEntries(settings?.social ?? null, { label: '', url: '' }),
+        footer_hours: ensureHours(settings?.footer_hours ?? null),
+        logo: null,
+        og_image: null,
     });
+
+    useEffect(() => {
+        if (props.flash?.success) {
+            setToastMessage(props.flash.success);
+            const timeout = setTimeout(() => setToastMessage(null), 3500);
+            return () => clearTimeout(timeout);
+        }
+
+        return undefined;
+    }, [props.flash?.success]);
+
+    useEffect(() => {
+        return () => {
+            if (logoPreview && logoPreview.startsWith('blob:')) {
+                URL.revokeObjectURL(logoPreview);
+            }
+            if (ogPreview && ogPreview.startsWith('blob:')) {
+                URL.revokeObjectURL(ogPreview);
+            }
+        };
+    }, [logoPreview, ogPreview]);
+
+    const showToast = (message: string) => {
+        setToastMessage(message);
+        setTimeout(() => setToastMessage(null), 3500);
+    };
+
+    const updateSocial = (index: number, key: keyof SocialLink, value: string) => {
+        const next = [...data.social];
+        next[index] = { ...next[index], [key]: value };
+        setData('social', next);
+    };
+
+    const addSocial = () => {
+        setData('social', [...data.social, { label: '', url: '' }]);
+    };
+
+    const removeSocial = (index: number) => {
+        const next = data.social.filter((_, idx) => idx !== index);
+        setData('social', next.length > 0 ? next : [{ label: '', url: '' }]);
+    };
+
+    const updateHour = (index: number, key: keyof FooterHour, value: string) => {
+        const next = [...data.footer_hours];
+        next[index] = { ...next[index], [key]: value };
+        setData('footer_hours', next);
+    };
+
+    const addHour = () => {
+        setData('footer_hours', [...data.footer_hours, { day: '', time: '' }]);
+    };
+
+    const removeHour = (index: number) => {
+        const next = data.footer_hours.filter((_, idx) => idx !== index);
+        setData('footer_hours', next.length > 0 ? next : [{ day: '', time: '' }]);
+    };
+
+    const handleLogoChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+        const file = event.target.files?.[0] ?? null;
+        setData('logo', file);
+
+        if (logoPreview && logoPreview.startsWith('blob:')) {
+            URL.revokeObjectURL(logoPreview);
+        }
+
+        setLogoPreview(file ? URL.createObjectURL(file) : settings?.logo_url ?? null);
+    };
+
+    const handleOgChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+        const file = event.target.files?.[0] ?? null;
+        setData('og_image', file);
+
+        if (ogPreview && ogPreview.startsWith('blob:')) {
+            URL.revokeObjectURL(ogPreview);
+        }
+
+        setOgPreview(file ? URL.createObjectURL(file) : settings?.og_image_url ?? null);
+    };
 
     const submit = (event: React.FormEvent<HTMLFormElement>) => {
         event.preventDefault();
-        router.post('/admin/settings', { ...data, _method: 'put' });
+
+        const social = data.social.filter((item) => item.label.trim() && item.url.trim());
+        const footerHours = data.footer_hours.filter((item) => item.day.trim() && item.time.trim());
+
+        const payload: Record<string, unknown> = {
+            site_name: data.site_name,
+            tagline: data.tagline,
+            address: data.address,
+            phone: data.phone,
+            whatsapp: data.whatsapp,
+            email: data.email,
+            social,
+            footer_hours: footerHours,
+        };
+
+        if (data.logo) {
+            payload.logo = data.logo;
+        }
+
+        if (data.og_image) {
+            payload.og_image = data.og_image;
+        }
+
+        payload._method = 'put';
+
+        post('/admin/settings', {
+            data: payload,
+            forceFormData: true,
+            preserveScroll: true,
+            onSuccess: () => {
+                showToast('Pengaturan tersimpan.');
+                reset('logo', 'og_image');
+            },
+        });
     };
 
     return (
         <AdminLayout title="Pengaturan Umum">
-            <form onSubmit={submit} className="max-w-xl space-y-3">
-                <input
-                    className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-slate-900 placeholder-slate-500 dark:border-slate-600 dark:bg-slate-700 dark:text-white dark:placeholder-slate-400"
-                    placeholder="Nama Situs"
-                    value={data.site_name}
-                    onChange={(event) => setData({ ...data, site_name: event.target.value })}
-                    required
-                />
-                <input
-                    className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-slate-900 placeholder-slate-500 dark:border-slate-600 dark:bg-slate-700 dark:text-white dark:placeholder-slate-400"
-                    placeholder="Tagline"
-                    value={data.tagline}
-                    onChange={(event) => setData({ ...data, tagline: event.target.value })}
-                />
-                <input
-                    className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-slate-900 placeholder-slate-500 dark:border-slate-600 dark:bg-slate-700 dark:text-white dark:placeholder-slate-400"
-                    placeholder="Alamat"
-                    value={data.address}
-                    onChange={(event) => setData({ ...data, address: event.target.value })}
-                />
-                <input
-                    className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-slate-900 placeholder-slate-500 dark:border-slate-600 dark:bg-slate-700 dark:text-white dark:placeholder-slate-400"
-                    placeholder="No. Telepon"
-                    value={data.phone}
-                    onChange={(event) => setData({ ...data, phone: event.target.value })}
-                />
-                <input
-                    className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-slate-900 placeholder-slate-500 dark:border-slate-600 dark:bg-slate-700 dark:text-white dark:placeholder-slate-400"
-                    placeholder="Fax"
-                    value={data.fax}
-                    onChange={(event) => setData({ ...data, fax: event.target.value })}
-                />
-                <input
-                    className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-slate-900 placeholder-slate-500 dark:border-slate-600 dark:bg-slate-700 dark:text-white dark:placeholder-slate-400"
-                    placeholder="Email"
-                    value={data.email}
-                    onChange={(event) => setData({ ...data, email: event.target.value })}
-                />
-                <input
-                    className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-slate-900 placeholder-slate-500 dark:border-slate-600 dark:bg-slate-700 dark:text-white dark:placeholder-slate-400"
-                    placeholder="Logo URL (opsional)"
-                    value={data.logo_path}
-                    onChange={(event) => setData({ ...data, logo_path: event.target.value })}
-                />
-                <button className="rounded-xl bg-slate-900 px-4 py-2 text-sm text-white dark:bg-slate-700">Simpan</button>
+            <form onSubmit={submit} className="mx-auto flex w-full max-w-4xl flex-col gap-6" encType="multipart/form-data">
+                <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-800">
+                    <div className="mb-6 flex flex-col gap-2">
+                        <h2 className="text-lg font-semibold text-slate-900 dark:text-white">Profil Sekolah</h2>
+                        <p className="text-sm text-slate-500 dark:text-slate-400">Perbarui identitas utama sekolah yang tampil di seluruh halaman publik.</p>
+                    </div>
+                    <div className="grid gap-4 md:grid-cols-2">
+                        <div>
+                            <label className="block text-sm font-medium text-slate-700 dark:text-slate-300">Nama Sekolah</label>
+                            <input
+                                value={data.site_name}
+                                onChange={(event) => setData('site_name', event.target.value)}
+                                className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
+                                required
+                            />
+                            {errors.site_name ? <p className="mt-1 text-xs text-rose-500">{errors.site_name}</p> : null}
+                        </div>
+                        <div>
+                            <label className="block text-sm font-medium text-slate-700 dark:text-slate-300">Tagline</label>
+                            <input
+                                value={data.tagline}
+                                onChange={(event) => setData('tagline', event.target.value)}
+                                className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
+                            />
+                            {errors.tagline ? <p className="mt-1 text-xs text-rose-500">{errors.tagline}</p> : null}
+                        </div>
+                        <div>
+                            <label className="block text-sm font-medium text-slate-700 dark:text-slate-300">Alamat</label>
+                            <textarea
+                                value={data.address}
+                                onChange={(event) => setData('address', event.target.value)}
+                                rows={3}
+                                className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
+                            />
+                            {errors.address ? <p className="mt-1 text-xs text-rose-500">{errors.address}</p> : null}
+                        </div>
+                        <div className="space-y-4">
+                            <div>
+                                <label className="block text-sm font-medium text-slate-700 dark:text-slate-300">Telepon</label>
+                                <input
+                                    value={data.phone}
+                                    onChange={(event) => setData('phone', event.target.value)}
+                                    className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
+                                />
+                                {errors.phone ? <p className="mt-1 text-xs text-rose-500">{errors.phone}</p> : null}
+                            </div>
+                            <div>
+                                <label className="block text-sm font-medium text-slate-700 dark:text-slate-300">WhatsApp</label>
+                                <input
+                                    value={data.whatsapp}
+                                    onChange={(event) => setData('whatsapp', event.target.value)}
+                                    className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
+                                />
+                                {errors.whatsapp ? <p className="mt-1 text-xs text-rose-500">{errors.whatsapp}</p> : null}
+                            </div>
+                            <div>
+                                <label className="block text-sm font-medium text-slate-700 dark:text-slate-300">Email</label>
+                                <input
+                                    type="email"
+                                    value={data.email}
+                                    onChange={(event) => setData('email', event.target.value)}
+                                    className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
+                                />
+                                {errors.email ? <p className="mt-1 text-xs text-rose-500">{errors.email}</p> : null}
+                            </div>
+                        </div>
+                    </div>
+                </section>
+
+                <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-800">
+                    <div className="mb-4 flex flex-col gap-2">
+                        <h2 className="text-lg font-semibold text-slate-900 dark:text-white">Branding &amp; Logo</h2>
+                        <p className="text-sm text-slate-500 dark:text-slate-400">Unggah logo utama dan gambar Open Graph default yang akan digunakan saat konten dibagikan.</p>
+                    </div>
+                    <div className="grid gap-6 md:grid-cols-[minmax(0,260px)_1fr]">
+                        <div className="space-y-4">
+                            <div>
+                                <label className="block text-sm font-medium text-slate-700 dark:text-slate-300" htmlFor="logo">Logo</label>
+                                <input
+                                    id="logo"
+                                    type="file"
+                                    accept="image/jpeg,image/png,image/webp"
+                                    onChange={handleLogoChange}
+                                    className="mt-1 block w-full rounded-xl border border-dashed border-slate-300 bg-slate-50 px-3 py-2 text-sm text-slate-600 file:mr-4 file:rounded-lg file:border-0 file:bg-slate-900 file:px-4 file:py-2 file:text-sm file:font-semibold file:text-white hover:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-300 dark:file:bg-slate-700"
+                                />
+                                {errors.logo ? <p className="mt-1 text-xs text-rose-500">{errors.logo}</p> : null}
+                            </div>
+                            <div>
+                                <label className="block text-sm font-medium text-slate-700 dark:text-slate-300" htmlFor="og">Default OG Image</label>
+                                <input
+                                    id="og"
+                                    type="file"
+                                    accept="image/jpeg,image/png,image/webp"
+                                    onChange={handleOgChange}
+                                    className="mt-1 block w-full rounded-xl border border-dashed border-slate-300 bg-slate-50 px-3 py-2 text-sm text-slate-600 file:mr-4 file:rounded-lg file:border-0 file:bg-slate-900 file:px-4 file:py-2 file:text-sm file:font-semibold file:text-white hover:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-300 dark:file:bg-slate-700"
+                                />
+                                {errors.og_image ? <p className="mt-1 text-xs text-rose-500">{errors.og_image}</p> : null}
+                            </div>
+                        </div>
+                        <div className="space-y-4">
+                            <div className="rounded-2xl border border-slate-200 bg-slate-50 p-4 dark:border-slate-600 dark:bg-slate-900">
+                                <p className="text-sm font-semibold text-slate-700 dark:text-slate-100">Pratinjau Logo</p>
+                                <div className="mt-3 flex h-36 items-center justify-center rounded-xl bg-white dark:bg-slate-800">
+                                    {logoPreview ? (
+                                        <img src={logoPreview} alt="Logo preview" className="max-h-28 max-w-full object-contain" />
+                                    ) : (
+                                        <span className="text-sm text-slate-500 dark:text-slate-400">Belum ada logo.</span>
+                                    )}
+                                </div>
+                            </div>
+                            <div className="rounded-2xl border border-slate-200 bg-slate-50 p-4 dark:border-slate-600 dark:bg-slate-900">
+                                <p className="text-sm font-semibold text-slate-700 dark:text-slate-100">Pratinjau OG Default</p>
+                                <div className="mt-3 h-40 overflow-hidden rounded-xl bg-white dark:bg-slate-800">
+                                    {ogPreview ? (
+                                        <img src={ogPreview} alt="OG preview" className="h-full w-full object-cover" />
+                                    ) : (
+                                        <div className="flex h-full items-center justify-center text-sm text-slate-500 dark:text-slate-400">Belum ada gambar OG.</div>
+                                    )}
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </section>
+
+                <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-800">
+                    <div className="mb-4 flex flex-col gap-2">
+                        <h2 className="text-lg font-semibold text-slate-900 dark:text-white">Kehadiran Digital</h2>
+                        <p className="text-sm text-slate-500 dark:text-slate-400">Kelola tautan sosial media dan jam layanan yang tampil di footer situs.</p>
+                    </div>
+                    <div className="grid gap-6 md:grid-cols-2">
+                        <div className="space-y-3">
+                            <div className="flex items-center justify-between">
+                                <h3 className="text-sm font-semibold text-slate-700 dark:text-slate-200">Tautan Sosial</h3>
+                                <button
+                                    type="button"
+                                    onClick={addSocial}
+                                    className="rounded-lg border border-slate-300 px-3 py-1 text-xs font-semibold text-slate-700 hover:bg-slate-100 dark:border-slate-600 dark:text-slate-200"
+                                >
+                                    Tambah
+                                </button>
+                            </div>
+                            <div className="space-y-3">
+                                {data.social.map((link, index) => (
+                                    <div key={`social-${index}`} className="grid gap-2 rounded-xl border border-slate-200 bg-slate-50 p-3 dark:border-slate-600 dark:bg-slate-900">
+                                        <input
+                                            value={link.label}
+                                            onChange={(event) => updateSocial(index, 'label', event.target.value)}
+                                            placeholder="Nama platform"
+                                            className="rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
+                                        />
+                                        <input
+                                            value={link.url}
+                                            onChange={(event) => updateSocial(index, 'url', event.target.value)}
+                                            placeholder="https://..."
+                                            className="rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
+                                        />
+                                        <button
+                                            type="button"
+                                            onClick={() => removeSocial(index)}
+                                            className="self-end rounded-lg border border-rose-200 px-3 py-1 text-xs font-semibold text-rose-500 hover:bg-rose-50 dark:border-rose-700 dark:text-rose-300"
+                                        >
+                                            Hapus
+                                        </button>
+                                    </div>
+                                ))}
+                            </div>
+                            {errors.social ? <p className="text-xs text-rose-500">{errors.social}</p> : null}
+                        </div>
+                        <div className="space-y-3">
+                            <div className="flex items-center justify-between">
+                                <h3 className="text-sm font-semibold text-slate-700 dark:text-slate-200">Jam Layanan Footer</h3>
+                                <button
+                                    type="button"
+                                    onClick={addHour}
+                                    className="rounded-lg border border-slate-300 px-3 py-1 text-xs font-semibold text-slate-700 hover:bg-slate-100 dark:border-slate-600 dark:text-slate-200"
+                                >
+                                    Tambah
+                                </button>
+                            </div>
+                            <div className="space-y-3">
+                                {data.footer_hours.map((hour, index) => (
+                                    <div key={`hour-${index}`} className="grid gap-2 rounded-xl border border-slate-200 bg-slate-50 p-3 dark:border-slate-600 dark:bg-slate-900">
+                                        <input
+                                            value={hour.day}
+                                            onChange={(event) => updateHour(index, 'day', event.target.value)}
+                                            placeholder="Senin - Jumat"
+                                            className="rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
+                                        />
+                                        <input
+                                            value={hour.time}
+                                            onChange={(event) => updateHour(index, 'time', event.target.value)}
+                                            placeholder="07.00 - 16.00 WIB"
+                                            className="rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
+                                        />
+                                        <button
+                                            type="button"
+                                            onClick={() => removeHour(index)}
+                                            className="self-end rounded-lg border border-rose-200 px-3 py-1 text-xs font-semibold text-rose-500 hover:bg-rose-50 dark:border-rose-700 dark:text-rose-300"
+                                        >
+                                            Hapus
+                                        </button>
+                                    </div>
+                                ))}
+                            </div>
+                            {errors.footer_hours ? <p className="text-xs text-rose-500">{errors.footer_hours}</p> : null}
+                        </div>
+                    </div>
+                </section>
+
+                <div className="flex items-center justify-end gap-2">
+                    <a
+                        href="/admin"
+                        className="rounded-xl border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:bg-slate-100 dark:border-slate-600 dark:bg-slate-800 dark:text-white"
+                    >
+                        Batal
+                    </a>
+                    <button
+                        type="submit"
+                        disabled={processing}
+                        className="rounded-xl bg-slate-900 px-5 py-2 text-sm font-semibold text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-slate-700 dark:hover:bg-slate-600"
+                    >
+                        {processing ? 'Menyimpan...' : 'Simpan'}
+                    </button>
+                </div>
             </form>
+            {toastMessage ? <Toast message={toastMessage} /> : null}
         </AdminLayout>
     );
 }

--- a/resources/js/pages/admin/voc/Form.tsx
+++ b/resources/js/pages/admin/voc/Form.tsx
@@ -1,19 +1,21 @@
-import React, { useState } from 'react';
-import { router, useForm, usePage } from '@inertiajs/react';
+import { useEffect, useMemo, useState } from 'react';
+import { useForm, usePage } from '@inertiajs/react';
 import AdminLayout from '@/pages/admin/_layout/AdminLayout';
 
-type MediaItem = {
+type ProgramStatus = 'draft' | 'scheduled' | 'published' | 'archived';
+
+type MediaResource = {
     id: number;
-    type: string;
     url: string;
-    alt?: string;
+    alt?: string | null;
+    type?: string | null;
 };
 
 type VocationalItem = {
     id?: number;
-    slug?: string;
-    title?: string;
-    icon?: string | null;
+    slug?: string | null;
+    title?: string | null;
+    summary?: string | null;
     description?: string | null;
     audience?: string | null;
     duration?: string | null;
@@ -21,480 +23,590 @@ type VocationalItem = {
     outcomes?: string[] | null;
     facilities?: string[] | null;
     mentors?: string[] | null;
-    photos?: string[] | null;
-    media?: MediaItem[];
+    contact_person?: string | null;
+    cta_url?: string | null;
+    status?: ProgramStatus | null;
+    published_at?: string | null;
+    seo_title?: string | null;
+    seo_description?: string | null;
+    cover_url?: string | null;
+    cover_alt?: string | null;
+    media?: MediaResource[];
 };
+
+type PageProps = {
+    errors?: Record<string, string>;
+    flash?: { success?: string };
+};
+
+type FormValues = {
+    slug: string;
+    title: string;
+    summary: string;
+    description: string;
+    audience: string;
+    duration: string;
+    schedule: string;
+    kurikulum: string[];
+    fasilitas: string[];
+    contact_person: string;
+    cta_url: string;
+    status: ProgramStatus;
+    published_at: string;
+    seo_title: string;
+    seo_description: string;
+    cover: File | null;
+    cover_alt: string;
+    gallery: File[];
+    gallery_alt: string[];
+};
+
+const STATUS_OPTIONS: Array<{ value: ProgramStatus; label: string }> = [
+    { value: 'draft', label: 'Draft' },
+    { value: 'scheduled', label: 'Terjadwal' },
+    { value: 'published', label: 'Publikasi' },
+    { value: 'archived', label: 'Arsip' },
+];
+
+function Toast({ message }: { message: string }) {
+    return (
+        <div className="fixed bottom-6 right-6 z-50 rounded-xl bg-slate-900 px-4 py-3 text-sm font-semibold text-white shadow-xl dark:bg-emerald-500">
+            {message}
+        </div>
+    );
+}
 
 type VocFormProps = {
     item?: VocationalItem;
 };
 
-type FormDataType = {
-    slug: string;
-    title: string;
-    icon: string;
-    audience: string;
-    duration: string;
-    schedule: string;
-    description: string;
-    outcomes: string[];
-    facilities: string[];
-    mentors: string[];
-    photos: File[];
+const ensureArray = (value?: string[] | null): string[] => {
+    if (!value || value.length === 0) {
+        return [''];
+    }
+
+    return value;
 };
 
 export default function VocForm({ item }: VocFormProps) {
     const isEdit = Boolean(item?.id);
-    const { data, setData, post, put } = useForm({
+    const { props } = usePage<PageProps>();
+    const [toastMessage, setToastMessage] = useState<string | null>(props.flash?.success ?? null);
+    const [coverPreview, setCoverPreview] = useState<string | null>(item?.cover_url ?? null);
+    const [galleryPreviews, setGalleryPreviews] = useState<string[]>([]);
+
+    const { data, setData, post, processing, errors, reset } = useForm<FormValues>({
         slug: item?.slug ?? '',
         title: item?.title ?? '',
-        icon: item?.icon ?? '',
+        summary: item?.summary ?? '',
+        description: item?.description ?? '',
         audience: item?.audience ?? '',
         duration: item?.duration ?? '',
         schedule: item?.schedule ?? '',
-        description: item?.description ?? '',
-        outcomes: item?.outcomes ?? [],
-        facilities: item?.facilities ?? [],
-        mentors: item?.mentors ?? [],
-        photos: [] as File[],
+        kurikulum: ensureArray(item?.outcomes ?? null),
+        fasilitas: ensureArray(item?.facilities ?? null),
+        contact_person: item?.contact_person ?? '',
+        cta_url: item?.cta_url ?? '',
+        status: item?.status ?? 'draft',
+        published_at: item?.published_at ? item.published_at.slice(0, 16) : '',
+        seo_title: item?.seo_title ?? '',
+        seo_description: item?.seo_description ?? '',
+        cover: null,
+        cover_alt: item?.cover_alt ?? '',
+        gallery: [],
+        gallery_alt: [],
     });
 
-    const [existingMedia, setExistingMedia] = useState<MediaItem[]>(item?.media ?? []);
+    const existingGallery = useMemo(() => item?.media ?? [], [item?.media]);
+
+    useEffect(() => {
+        if (props.flash?.success) {
+            setToastMessage(props.flash.success);
+            const timeout = setTimeout(() => setToastMessage(null), 3500);
+            return () => clearTimeout(timeout);
+        }
+
+        return undefined;
+    }, [props.flash?.success]);
+
+    useEffect(() => {
+        return () => {
+            if (coverPreview && coverPreview.startsWith('blob:')) {
+                URL.revokeObjectURL(coverPreview);
+            }
+        };
+    }, [coverPreview]);
+
+    useEffect(() => {
+        return () => {
+            galleryPreviews.forEach((url) => {
+                if (url.startsWith('blob:')) {
+                    URL.revokeObjectURL(url);
+                }
+            });
+        };
+    }, [galleryPreviews]);
+
+    const showToast = (message: string) => {
+        setToastMessage(message);
+        setTimeout(() => setToastMessage(null), 3500);
+    };
+
+    const updateArrayField = (field: 'kurikulum' | 'fasilitas', index: number, value: string) => {
+        const next = [...data[field]];
+        next[index] = value;
+        setData(field, next);
+    };
+
+    const addArrayField = (field: 'kurikulum' | 'fasilitas') => {
+        setData(field, [...data[field], '']);
+    };
+
+    const removeArrayField = (field: 'kurikulum' | 'fasilitas', index: number) => {
+        const next = data[field].filter((_, idx) => idx != index);
+        setData(field, next.length > 0 ? next : ['']);
+    };
+
+    const handleCoverChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+        const file = event.target.files?.[0] ?? null;
+        setData('cover', file);
+
+        if (coverPreview && coverPreview.startsWith('blob:')) {
+            URL.revokeObjectURL(coverPreview);
+        }
+
+        setCoverPreview(file ? URL.createObjectURL(file) : item?.cover_url ?? null);
+    };
+
+    const handleGalleryChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+        const files = event.target.files ? Array.from(event.target.files) : [];
+
+        setData('gallery', files);
+        setData('gallery_alt', files.map((_, index) => data.gallery_alt[index] ?? ''));
+
+        setGalleryPreviews((prev) => {
+            prev.forEach((url) => {
+                if (url.startsWith('blob:')) {
+                    URL.revokeObjectURL(url);
+                }
+            });
+
+            return files.map((file) => URL.createObjectURL(file));
+        });
+    };
+
+    const updateGalleryAlt = (index: number, value: string) => {
+        const next = [...data.gallery_alt];
+        next[index] = value;
+        setData('gallery_alt', next);
+    };
 
     const submit = (event: React.FormEvent<HTMLFormElement>) => {
         event.preventDefault();
 
-        console.log('Form data being sent:', data);
-        console.log('Files in data.photos:', data.photos);
-        console.log('Files count:', data.photos.length);
+        const trimmedKurikulum = data.kurikulum.map((entry) => entry.trim()).filter(Boolean);
+        const trimmedFasilitas = data.fasilitas.map((entry) => entry.trim()).filter(Boolean);
+        const galleryAlt = data.gallery_alt
+            .slice(0, data.gallery.length)
+            .map((entry) => entry.trim());
 
-        // Create FormData to ensure files are sent properly
-        const formData = new FormData();
+        const payload: Record<string, unknown> = {
+            ...data,
+            kurikulum: trimmedKurikulum,
+            fasilitas: trimmedFasilitas,
+            gallery_alt: galleryAlt,
+            published_at: data.published_at ? new Date(data.published_at).toISOString() : null,
+        };
 
-        // Add all form fields
-        formData.append('slug', data.slug);
-        formData.append('title', data.title);
-        formData.append('icon', data.icon);
-        formData.append('audience', data.audience);
-        formData.append('duration', data.duration);
-        formData.append('schedule', data.schedule);
-        formData.append('description', data.description);
-
-        // Handle array fields
-        data.outcomes.forEach((outcome, index) => {
-            formData.append(`outcomes[${index}]`, outcome);
-        });
-        data.facilities.forEach((facility, index) => {
-            formData.append(`facilities[${index}]`, facility);
-        });
-        data.mentors.forEach((mentor, index) => {
-            formData.append(`mentors[${index}]`, mentor);
-        });
-
-        // Handle file array
-        data.photos.forEach((file: File) => {
-            formData.append('photos[]', file);
-        });
-
-        console.log('FormData created with entries:');
-        for (let [key, value] of formData.entries()) {
-            console.log(key, value);
+        if (!data.cover) {
+            delete payload.cover;
         }
 
-        if (isEdit) {
-            console.log('Calling router.post for update with _method=PUT');
-            formData.append('_method', 'PUT');
-            router.post(`/admin/vocational-programs/${item?.id}`, formData, {
-                onSuccess: () => {
-                    console.log('Update successful');
-                    window.location.reload();
-                },
-                onError: (errors) => {
-                    console.error('Update errors:', errors);
-                },
-            });
-        } else {
-            console.log('Calling router.post for create');
-            router.post('/admin/vocational-programs', formData, {
-                onSuccess: () => {
-                    console.log('Create successful');
-                    window.location.reload();
-                },
-                onError: (errors) => {
-                    console.error('Create errors:', errors);
-                },
-            });
+        if (!data.gallery.length) {
+            delete payload.gallery;
+            delete payload.gallery_alt;
         }
-    };
 
-    const handleDeletePhoto = (index: number) => {
-        const newPhotos = [...data.photos];
-        newPhotos.splice(index, 1);
-        setData('photos', newPhotos);
-    };
+        if (isEdit && item?.id) {
+            payload._method = 'put';
+        }
 
-    const textareaToArray = (value: string) => value.split('\n').map((line) => line.trim()).filter(Boolean);
+        post(isEdit && item?.id ? `/admin/vocational-programs/${item.id}` : '/admin/vocational-programs', {
+            data: payload,
+            forceFormData: true,
+            preserveScroll: true,
+            onSuccess: () => {
+                showToast(isEdit ? 'Program diperbarui.' : 'Program dibuat.');
 
-    const handlePhotoChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-        const files = e.target.files ? Array.from(e.target.files) : [];
-        // Append new files to existing photos array instead of replacing
-        setData('photos', [...data.photos, ...files]);
+                if (!isEdit) {
+                    reset();
+                    setCoverPreview(null);
+                    setGalleryPreviews((prev) => {
+                        prev.forEach((url) => {
+                            if (url.startsWith('blob:')) {
+                                URL.revokeObjectURL(url);
+                            }
+                        });
+
+                        return [];
+                    });
+                }
+            },
+        });
     };
 
     return (
         <AdminLayout title={`${isEdit ? 'Edit' : 'Tambah'} Program Vokasional`}>
-            <div className="max-w-4xl mx-auto">
-                <form onSubmit={submit} encType="multipart/form-data" className="bg-white dark:bg-slate-800 rounded-2xl shadow-lg p-8 space-y-8">
-                    {/* Header Section */}
-                    <div className="border-b border-slate-200 dark:border-slate-700 pb-6">
-                        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-2">
-                            {isEdit ? 'Edit Program Vokasional' : 'Tambah Program Vokasional Baru'}
-                        </h2>
-                        <p className="text-slate-600 dark:text-slate-400">
-                            Lengkapi informasi program vokasional dengan detail yang diperlukan
+            <form onSubmit={submit} className="mx-auto flex w-full max-w-5xl flex-col gap-6" encType="multipart/form-data">
+                <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-800">
+                    <div className="mb-6 flex flex-col gap-2">
+                        <h2 className="text-lg font-semibold text-slate-900 dark:text-white">Identitas Program</h2>
+                        <p className="text-sm text-slate-500 dark:text-slate-400">
+                            Slug dan judul akan muncul di URL publik. Tambahkan ringkasan singkat untuk memperkenalkan program.
                         </p>
                     </div>
-
-                    {/* Basic Information Section */}
-                    <div className="space-y-6">
-                        <h3 className="text-lg font-semibold text-slate-900 dark:text-white flex items-center">
-                            <span className="w-8 h-8 bg-blue-100 dark:bg-blue-900 rounded-lg flex items-center justify-center mr-3">
-                                <svg className="w-4 h-4 text-blue-600 dark:text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-                                </svg>
-                            </span>
-                            Informasi Dasar
-                        </h3>
-
-                        <div className="grid gap-6 md:grid-cols-2">
-                            <div className="space-y-2">
-                                <label className="block text-sm font-medium text-slate-700 dark:text-slate-300">
-                                    Slug <span className="text-red-500">*</span>
-                                </label>
-                                <input
-                                    type="text"
-                                    className="w-full px-4 py-3 border border-slate-300 dark:border-slate-600 rounded-xl bg-white dark:bg-slate-700 text-slate-900 dark:text-white placeholder-slate-500 dark:placeholder-slate-400 focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all duration-200"
-                                    placeholder="contoh: program-teknik-komputer"
-                                    value={data.slug}
-                                    onChange={(event) => setData('slug', event.target.value)}
-                                    required
-                                />
-                            </div>
-
-                            <div className="space-y-2">
-                                <label className="block text-sm font-medium text-slate-700 dark:text-slate-300">
-                                    Judul Program <span className="text-red-500">*</span>
-                                </label>
-                                <input
-                                    type="text"
-                                    className="w-full px-4 py-3 border border-slate-300 dark:border-slate-600 rounded-xl bg-white dark:bg-slate-700 text-slate-900 dark:text-white placeholder-slate-500 dark:placeholder-slate-400 focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all duration-200"
-                                    placeholder="contoh: Teknik Komputer dan Jaringan"
-                                    value={data.title}
-                                    onChange={(event) => setData('title', event.target.value)}
-                                    required
-                                />
-                            </div>
-
-                            <div className="space-y-2">
-                                <label className="block text-sm font-medium text-slate-700 dark:text-slate-300">
-                                    Icon (Opsional)
-                                </label>
-                                <input
-                                    type="text"
-                                    className="w-full px-4 py-3 border border-slate-300 dark:border-slate-600 rounded-xl bg-white dark:bg-slate-700 text-slate-900 dark:text-white placeholder-slate-500 dark:placeholder-slate-400 focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all duration-200"
-                                    placeholder="contoh: computer"
-                                    value={data.icon}
-                                    onChange={(event) => setData('icon', event.target.value)}
-                                />
-                            </div>
-
-                            <div className="space-y-2">
-                                <label className="block text-sm font-medium text-slate-700 dark:text-slate-300">
-                                    Target Audience (Opsional)
-                                </label>
-                                <input
-                                    type="text"
-                                    className="w-full px-4 py-3 border border-slate-300 dark:border-slate-600 rounded-xl bg-white dark:bg-slate-700 text-slate-900 dark:text-white placeholder-slate-500 dark:placeholder-slate-400 focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all duration-200"
-                                    placeholder="contoh: Siswa SMA/SMK"
-                                    value={data.audience}
-                                    onChange={(event) => setData('audience', event.target.value)}
-                                />
-                            </div>
-
-                            <div className="space-y-2">
-                                <label className="block text-sm font-medium text-slate-700 dark:text-slate-300">
-                                    Durasi Program
-                                </label>
-                                <input
-                                    type="text"
-                                    className="w-full px-4 py-3 border border-slate-300 dark:border-slate-600 rounded-xl bg-white dark:bg-slate-700 text-slate-900 dark:text-white placeholder-slate-500 dark:placeholder-slate-400 focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all duration-200"
-                                    placeholder="contoh: 6 bulan"
-                                    value={data.duration}
-                                    onChange={(event) => setData('duration', event.target.value)}
-                                />
-                            </div>
-
-                            <div className="space-y-2">
-                                <label className="block text-sm font-medium text-slate-700 dark:text-slate-300">
-                                    Jadwal
-                                </label>
-                                <input
-                                    type="text"
-                                    className="w-full px-4 py-3 border border-slate-300 dark:border-slate-600 rounded-xl bg-white dark:bg-slate-700 text-slate-900 dark:text-white placeholder-slate-500 dark:placeholder-slate-400 focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all duration-200"
-                                    placeholder="contoh: Senin - Jumat, 08:00 - 16:00"
-                                    value={data.schedule}
-                                    onChange={(event) => setData('schedule', event.target.value)}
-                                />
-                            </div>
-                        </div>
-                    </div>
-
-                    {/* Description Section */}
-                    <div className="space-y-4">
-                        <h3 className="text-lg font-semibold text-slate-900 dark:text-white flex items-center">
-                            <span className="w-8 h-8 bg-green-100 dark:bg-green-900 rounded-lg flex items-center justify-center mr-3">
-                                <svg className="w-4 h-4 text-green-600 dark:text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-                                </svg>
-                            </span>
-                            Deskripsi Program
-                        </h3>
-
-                        <div className="space-y-2">
-                            <textarea
-                                className="w-full px-4 py-3 border border-slate-300 dark:border-slate-600 rounded-xl bg-white dark:bg-slate-700 text-slate-900 dark:text-white placeholder-slate-500 dark:placeholder-slate-400 focus:ring-2 focus:ring-green-500 focus:border-transparent transition-all duration-200 resize-vertical min-h-[120px]"
-                                placeholder="Jelaskan secara detail tentang program vokasional ini, tujuan, manfaat, dan hal-hal penting lainnya..."
-                                value={data.description}
-                                onChange={(event) => setData('description', event.target.value)}
-                                rows={4}
+                    <div className="grid gap-4 md:grid-cols-2">
+                        <div>
+                            <label className="block text-sm font-medium text-slate-700 dark:text-slate-300">Slug</label>
+                            <input
+                                value={data.slug}
+                                onChange={(event) => setData('slug', event.target.value)}
+                                className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
+                                placeholder="program-teknologi-asistif"
+                                required
                             />
+                            {errors.slug ? <p className="mt-1 text-xs text-rose-500">{errors.slug}</p> : null}
+                        </div>
+                        <div>
+                            <label className="block text-sm font-medium text-slate-700 dark:text-slate-300">Judul Program</label>
+                            <input
+                                value={data.title}
+                                onChange={(event) => setData('title', event.target.value)}
+                                className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
+                                required
+                            />
+                            {errors.title ? <p className="mt-1 text-xs text-rose-500">{errors.title}</p> : null}
+                        </div>
+                        <div className="md:col-span-2">
+                            <label className="block text-sm font-medium text-slate-700 dark:text-slate-300">Ringkasan</label>
+                            <textarea
+                                value={data.summary}
+                                onChange={(event) => setData('summary', event.target.value)}
+                                rows={3}
+                                className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
+                                placeholder="Gambarkan manfaat utama program secara singkat."
+                            />
+                            {errors.summary ? <p className="mt-1 text-xs text-rose-500">{errors.summary}</p> : null}
+                        </div>
+                        <div>
+                            <label className="block text-sm font-medium text-slate-700 dark:text-slate-300">Target Peserta</label>
+                            <input
+                                value={data.audience}
+                                onChange={(event) => setData('audience', event.target.value)}
+                                className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
+                            />
+                            {errors.audience ? <p className="mt-1 text-xs text-rose-500">{errors.audience}</p> : null}
+                        </div>
+                        <div>
+                            <label className="block text-sm font-medium text-slate-700 dark:text-slate-300">Durasi</label>
+                            <input
+                                value={data.duration}
+                                onChange={(event) => setData('duration', event.target.value)}
+                                placeholder="12 pertemuan"
+                                className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
+                            />
+                            {errors.duration ? <p className="mt-1 text-xs text-rose-500">{errors.duration}</p> : null}
+                        </div>
+                        <div>
+                            <label className="block text-sm font-medium text-slate-700 dark:text-slate-300">Jadwal</label>
+                            <input
+                                value={data.schedule}
+                                onChange={(event) => setData('schedule', event.target.value)}
+                                placeholder="Setiap Sabtu 09.00"
+                                className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
+                            />
+                            {errors.schedule ? <p className="mt-1 text-xs text-rose-500">{errors.schedule}</p> : null}
                         </div>
                     </div>
+                </section>
 
-                    {/* Detailed Information Section */}
-                    <div className="space-y-6">
-                        <h3 className="text-lg font-semibold text-slate-900 dark:text-white flex items-center">
-                            <span className="w-8 h-8 bg-purple-100 dark:bg-purple-900 rounded-lg flex items-center justify-center mr-3">
-                                <svg className="w-4 h-4 text-purple-600 dark:text-purple-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" />
-                                </svg>
-                            </span>
-                            Informasi Detail
-                        </h3>
-
-                        <div className="grid gap-6 md:grid-cols-1">
-                            <div className="space-y-2">
-                                <label className="block text-sm font-medium text-slate-700 dark:text-slate-300">
-                                    Hasil Pembelajaran (Outcomes)
-                                </label>
-                                <textarea
-                                    className="w-full px-4 py-3 border border-slate-300 dark:border-slate-600 rounded-xl bg-white dark:bg-slate-700 text-slate-900 dark:text-white placeholder-slate-500 dark:placeholder-slate-400 focus:ring-2 focus:ring-purple-500 focus:border-transparent transition-all duration-200 resize-vertical min-h-[100px]"
-                                    placeholder="Masukkan hasil pembelajaran yang akan dicapai, satu per baris:&#10;- Mampu mengoperasikan perangkat keras komputer&#10;- Memahami konsep jaringan komputer&#10;- Dapat melakukan troubleshooting dasar"
-                                    value={data.outcomes.join('\n')}
-                                    onChange={(event) => setData('outcomes', textareaToArray(event.target.value))}
-                                    rows={3}
-                                />
-                                <p className="text-xs text-slate-500 dark:text-slate-400">Satu outcome per baris</p>
+                <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-800">
+                    <div className="mb-4 flex flex-col gap-2">
+                        <h2 className="text-lg font-semibold text-slate-900 dark:text-white">Kurikulum &amp; Fasilitas</h2>
+                        <p className="text-sm text-slate-500 dark:text-slate-400">Rinci kompetensi utama dan fasilitas pendukung agar calon peserta memahami pengalaman belajar yang ditawarkan.</p>
+                    </div>
+                    <div className="grid gap-6 md:grid-cols-2">
+                        <div>
+                            <div className="flex items-center justify-between">
+                                <h3 className="text-sm font-semibold text-slate-700 dark:text-slate-200">Kurikulum</h3>
+                                <button
+                                    type="button"
+                                    onClick={() => addArrayField('kurikulum')}
+                                    className="rounded-lg border border-slate-300 px-3 py-1 text-xs font-semibold text-slate-700 hover:bg-slate-100 dark:border-slate-600 dark:text-slate-200"
+                                >
+                                    Tambah Baris
+                                </button>
                             </div>
-
-                            <div className="space-y-2">
-                                <label className="block text-sm font-medium text-slate-700 dark:text-slate-300">
-                                    Fasilitas yang Tersedia
-                                </label>
-                                <textarea
-                                    className="w-full px-4 py-3 border border-slate-300 dark:border-slate-600 rounded-xl bg-white dark:bg-slate-700 text-slate-900 dark:text-white placeholder-slate-500 dark:placeholder-slate-400 focus:ring-2 focus:ring-purple-500 focus:border-transparent transition-all duration-200 resize-vertical min-h-[100px]"
-                                    placeholder="Masukkan fasilitas yang tersedia, satu per baris:&#10;- Laboratorium Komputer&#10;- Ruang Kelas Ber-AC&#10;- Peralatan Networking Lengkap"
-                                    value={data.facilities.join('\n')}
-                                    onChange={(event) => setData('facilities', textareaToArray(event.target.value))}
-                                    rows={3}
-                                />
-                                <p className="text-xs text-slate-500 dark:text-slate-400">Satu fasilitas per baris</p>
+                            <div className="mt-3 space-y-3">
+                                {data.kurikulum.map((value, index) => (
+                                    <div key={`kurikulum-${index}`} className="flex gap-2">
+                                        <input
+                                            value={value}
+                                            onChange={(event) => updateArrayField('kurikulum', index, event.target.value)}
+                                            className="flex-1 rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
+                                            placeholder={`Kompetensi ${index + 1}`}
+                                        />
+                                        <button
+                                            type="button"
+                                            onClick={() => removeArrayField('kurikulum', index)}
+                                            className="rounded-lg border border-rose-200 px-3 py-2 text-xs font-semibold text-rose-500 hover:bg-rose-50 dark:border-rose-700 dark:text-rose-300"
+                                            aria-label="Hapus kurikulum"
+                                        >
+                                            Hapus
+                                        </button>
+                                    </div>
+                                ))}
                             </div>
-
-                            <div className="space-y-2">
-                                <label className="block text-sm font-medium text-slate-700 dark:text-slate-300">
-                                    Mentor/Pengajar
-                                </label>
-                                <textarea
-                                    className="w-full px-4 py-3 border border-slate-300 dark:border-slate-600 rounded-xl bg-white dark:bg-slate-700 text-slate-900 dark:text-white placeholder-slate-500 dark:placeholder-slate-400 focus:ring-2 focus:ring-purple-500 focus:border-transparent transition-all duration-200 resize-vertical min-h-[100px]"
-                                    placeholder="Masukkan nama mentor atau pengajar, satu per baris:&#10;- Ir. Ahmad Susanto, M.Kom&#10;- Siti Nurhaliza, S.Kom&#10;- Budi Santoso, M.T"
-                                    value={data.mentors.join('\n')}
-                                    onChange={(event) => setData('mentors', textareaToArray(event.target.value))}
-                                    rows={3}
-                                />
-                                <p className="text-xs text-slate-500 dark:text-slate-400">Satu mentor per baris</p>
+                            {errors.kurikulum ? <p className="mt-2 text-xs text-rose-500">{errors.kurikulum}</p> : null}
+                        </div>
+                        <div>
+                            <div className="flex items-center justify-between">
+                                <h3 className="text-sm font-semibold text-slate-700 dark:text-slate-200">Fasilitas</h3>
+                                <button
+                                    type="button"
+                                    onClick={() => addArrayField('fasilitas')}
+                                    className="rounded-lg border border-slate-300 px-3 py-1 text-xs font-semibold text-slate-700 hover:bg-slate-100 dark:border-slate-600 dark:text-slate-200"
+                                >
+                                    Tambah Baris
+                                </button>
                             </div>
+                            <div className="mt-3 space-y-3">
+                                {data.fasilitas.map((value, index) => (
+                                    <div key={`fasilitas-${index}`} className="flex gap-2">
+                                        <input
+                                            value={value}
+                                            onChange={(event) => updateArrayField('fasilitas', index, event.target.value)}
+                                            className="flex-1 rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
+                                            placeholder={`Fasilitas ${index + 1}`}
+                                        />
+                                        <button
+                                            type="button"
+                                            onClick={() => removeArrayField('fasilitas', index)}
+                                            className="rounded-lg border border-rose-200 px-3 py-2 text-xs font-semibold text-rose-500 hover:bg-rose-50 dark:border-rose-700 dark:text-rose-300"
+                                            aria-label="Hapus fasilitas"
+                                        >
+                                            Hapus
+                                        </button>
+                                    </div>
+                                ))}
+                            </div>
+                            {errors.fasilitas ? <p className="mt-2 text-xs text-rose-500">{errors.fasilitas}</p> : null}
                         </div>
                     </div>
+                </section>
 
-                    {/* Photo Upload Section */}
-                    <div className="space-y-6">
-                        <h3 className="text-lg font-semibold text-slate-900 dark:text-white flex items-center">
-                            <span className="w-8 h-8 bg-orange-100 dark:bg-orange-900 rounded-lg flex items-center justify-center mr-3">
-                                <svg className="w-4 h-4 text-orange-600 dark:text-orange-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
-                                </svg>
-                            </span>
-                            Dokumentasi Foto
-                        </h3>
-
-                        <div className="space-y-4">
-                            <div
-                                className="border-2 border-dashed border-slate-300 dark:border-slate-600 rounded-xl p-8 text-center hover:border-blue-400 dark:hover:border-blue-500 transition-colors duration-200 cursor-pointer"
-                                onDragOver={(e) => {
-                                    e.preventDefault();
-                                    e.currentTarget.classList.add('border-blue-400', 'dark:border-blue-500');
-                                }}
-                                onDragLeave={(e) => {
-                                    e.preventDefault();
-                                    e.currentTarget.classList.remove('border-blue-400', 'dark:border-blue-500');
-                                }}
-                                onDrop={(e) => {
-                                    e.preventDefault();
-                                    e.currentTarget.classList.remove('border-blue-400', 'dark:border-blue-500');
-                                    const files = e.dataTransfer.files;
-                                    if (files.length > 0) {
-                                        const imageFiles = Array.from(files).filter(file => file.type.startsWith('image/'));
-                                        if (imageFiles.length > 0) {
-                                            setData('photos', [...data.photos, ...imageFiles]);
-                                        }
-                                    }
-                                }}
-                                onClick={() => document.getElementById('photo-upload')?.click()}
-                            >
-                                <div className="space-y-4">
-                                    <div className="mx-auto w-12 h-12 bg-slate-100 dark:bg-slate-700 rounded-full flex items-center justify-center">
-                                        <svg className="w-6 h-6 text-slate-600 dark:text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12" />
-                                        </svg>
-                                    </div>
-                                    <div>
-                                        <span className="text-lg font-medium text-slate-900 dark:text-white">Klik untuk upload foto</span>
-                                        <span className="text-slate-600 dark:text-slate-400 block">atau drag & drop</span>
-                                    </div>
-                                    <p className="text-sm text-slate-500 dark:text-slate-400">
-                                        PNG, JPG, GIF hingga 2MB per file • Multiple files diperbolehkan
-                                    </p>
-                                </div>
+                <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-800">
+                    <div className="mb-4 flex flex-col gap-2">
+                        <h2 className="text-lg font-semibold text-slate-900 dark:text-white">Media Program</h2>
+                        <p className="text-sm text-slate-500 dark:text-slate-400">Unggah cover utama dan galeri pendukung. Pastikan teks alternatif diisi untuk aksesibilitas.</p>
+                    </div>
+                    <div className="grid gap-6 md:grid-cols-[minmax(0,280px)_1fr]">
+                        <div className="space-y-3">
+                            <label className="block text-sm font-medium text-slate-700 dark:text-slate-300" htmlFor="cover">
+                                Cover Program
+                            </label>
+                            <input
+                                id="cover"
+                                type="file"
+                                accept="image/jpeg,image/png,image/webp"
+                                onChange={handleCoverChange}
+                                className="block w-full rounded-xl border border-dashed border-slate-300 bg-slate-50 px-3 py-2 text-sm text-slate-600 file:mr-4 file:rounded-lg file:border-0 file:bg-slate-900 file:px-4 file:py-2 file:text-sm file:font-semibold file:text-white hover:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-300 dark:file:bg-slate-700"
+                            />
+                            {errors.cover ? <p className="text-xs text-rose-500">{errors.cover}</p> : null}
+                            <input
+                                value={data.cover_alt}
+                                onChange={(event) => setData('cover_alt', event.target.value)}
+                                placeholder="Deskripsi cover"
+                                className="w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
+                            />
+                            {errors.cover_alt ? <p className="text-xs text-rose-500">{errors.cover_alt}</p> : null}
+                            <div className="pt-2">
+                                <label className="block text-sm font-medium text-slate-700 dark:text-slate-300" htmlFor="gallery">
+                                    Galeri (gambar/video)
+                                </label>
                                 <input
-                                    id="photo-upload"
+                                    id="gallery"
                                     type="file"
                                     multiple
-                                    accept="image/*"
-                                    onChange={handlePhotoChange}
-                                    className="hidden"
+                                    accept="image/jpeg,image/png,image/webp,video/mp4"
+                                    onChange={handleGalleryChange}
+                                    className="mt-1 block w-full rounded-xl border border-dashed border-slate-300 bg-slate-50 px-3 py-2 text-sm text-slate-600 file:mr-4 file:rounded-lg file:border-0 file:bg-slate-900 file:px-4 file:py-2 file:text-sm file:font-semibold file:text-white hover:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-300 dark:file:bg-slate-700"
                                 />
+                                {errors.gallery ? <p className="text-xs text-rose-500">{errors.gallery}</p> : null}
                             </div>
-
-                            {/* Photo Preview Grid */}
-                            {(existingMedia.length > 0 || data.photos.length > 0) && (
+                        </div>
+                        <div className="space-y-6">
+                            <div className="rounded-2xl border border-slate-200 bg-slate-50 p-4 dark:border-slate-600 dark:bg-slate-900">
+                                <p className="text-sm font-semibold text-slate-700 dark:text-slate-100">Pratinjau Cover</p>
+                                <div className="mt-3 h-48 overflow-hidden rounded-xl bg-slate-200 dark:bg-slate-800">
+                                    {coverPreview ? (
+                                        <img src={coverPreview} alt="Preview cover" className="h-full w-full object-cover" />
+                                    ) : (
+                                        <div className="flex h-full items-center justify-center text-sm text-slate-500 dark:text-slate-400">
+                                            Belum ada pratinjau cover.
+                                        </div>
+                                    )}
+                                </div>
+                            </div>
+                            {galleryPreviews.length > 0 ? (
                                 <div className="space-y-4">
-                                    <h4 className="text-md font-medium text-slate-900 dark:text-white">Foto Terupload</h4>
-                                    <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-                                        {existingMedia.map((mediaItem, index) => {
-                                            // Fix for black blank image: add timestamp query param to bust cache
-                                            const imageUrl = `/storage/${mediaItem.url}?t=${new Date().getTime()}`;
-                                            return (
-                                                <div key={mediaItem.id} className="relative group rounded-xl overflow-hidden bg-slate-100 dark:bg-slate-700">
-                                                    <img
-                                                        src={imageUrl}
-                                                        alt={mediaItem.alt || `Photo ${index + 1}`}
-                                                        className="w-full h-32 object-cover"
-                                                    />
-                                                    <div className="absolute inset-0 bg-opacity-0 group-hover:bg-opacity-30 transition-all duration-200 flex items-center justify-center">
-                                                        <button
-                                                            type="button"
-                                                            onClick={() => {
-                                                                if (confirm('Apakah Anda yakin ingin menghapus gambar ini?')) {
-                                                                    router.delete(`/admin/vocational-programs/${item?.id}/media/${mediaItem.id}`, {
-                                                                        onSuccess: () => {
-                                                                            setExistingMedia(prev => prev.filter(m => m.id !== mediaItem.id));
-                                                                        }
-                                                                    });
-                                                                }
-                                                            }}
-                                                            className="opacity-0 group-hover:opacity-100 bg-red-600 hover:bg-red-700 text-white rounded-full p-2 transition-all duration-200"
-                                                            aria-label="Hapus foto"
-                                                        >
-                                                            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-                                                            </svg>
-                                                        </button>
-                                                    </div>
-                                                    <div className="absolute bottom-2 left-2 bg-black bg-opacity-50 text-white text-xs px-2 py-1 rounded">
-                                                        Existing
-                                                    </div>
-                                                </div>
-                                            );
-                                        })}
-                                        {data.photos.map((file, index) => {
-                                            const previewUrl = URL.createObjectURL(file);
+                                    <p className="text-sm font-semibold text-slate-700 dark:text-slate-100">Galeri Baru</p>
+                                    {galleryPreviews.map((preview, index) => {
+                                        const galleryFieldKey = `gallery_alt.${index}`;
+                                        const galleryFieldError = (errors as Record<string, string | undefined>)[galleryFieldKey];
 
-                                            return (
-                                                <div key={`new-${index}`} className="relative group rounded-xl overflow-hidden bg-slate-100 dark:bg-slate-700">
-                                                    <img
-                                                        src={previewUrl}
-                                                        alt={`New Photo ${index + 1}`}
-                                                        className="w-full h-32 object-cover bg-white"
-                                                        onLoad={() => URL.revokeObjectURL(previewUrl)}
+                                        return (
+                                            <div key={`gallery-preview-${index}`} className="grid gap-3 rounded-2xl border border-slate-200 bg-white p-3 dark:border-slate-600 dark:bg-slate-800">
+                                                <div className="flex items-center gap-3">
+                                                    <div className="h-20 w-32 overflow-hidden rounded-xl bg-slate-200 dark:bg-slate-900">
+                                                        <img src={preview} alt={`Pratinjau galeri ${index + 1}`} className="h-full w-full object-cover" />
+                                                    </div>
+                                                    <div className="flex-1">
+                                                    <label className="block text-xs font-medium text-slate-500 dark:text-slate-300">Teks alternatif</label>
+                                                    <input
+                                                        value={data.gallery_alt[index] ?? ''}
+                                                        onChange={(event) => updateGalleryAlt(index, event.target.value)}
+                                                        required
+                                                        className="mt-1 w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
                                                     />
-                                                    <div className="absolute inset-0 bg-black bg-opacity-0 group-hover:bg-opacity-30 transition-all duration-200 flex items-center justify-center">
-                                                        <button
-                                                            type="button"
-                                                            onClick={() => handleDeletePhoto(index)}
-                                                            className="opacity-0 group-hover:opacity-100 bg-red-600 hover:bg-red-700 text-white rounded-full p-2 transition-all duration-200"
-                                                            aria-label="Hapus foto"
-                                                        >
-                                                            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-                                                            </svg>
-                                                        </button>
-                                                    </div>
-                                                    <div className="absolute bottom-2 left-2 bg-blue-600 text-white text-xs px-2 py-1 rounded">
-                                                        New ({file.name})
-                                                    </div>
                                                 </div>
-                                            );
-                                        })}
+                                            </div>
+                                            {galleryFieldError ? <p className="text-xs text-rose-500">{galleryFieldError}</p> : null}
+                                        </div>
+                                        );
+                                    })}
+                                </div>
+                            ) : null}
+                            {existingGallery.length > 0 ? (
+                                <div className="space-y-2">
+                                    <p className="text-sm font-semibold text-slate-700 dark:text-slate-100">Galeri Saat Ini</p>
+                                    <div className="grid gap-3 md:grid-cols-2">
+                                        {existingGallery.map((media) => (
+                                            <figure key={media.id} className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm dark:border-slate-600 dark:bg-slate-800">
+                                                <img src={media.url} alt={media.alt ?? ''} className="h-32 w-full object-cover" />
+                                                <figcaption className="px-3 py-2 text-xs text-slate-500 dark:text-slate-300">{media.alt ?? 'Tanpa deskripsi'}</figcaption>
+                                            </figure>
+                                        ))}
                                     </div>
                                 </div>
-                            )}
+                            ) : null}
                         </div>
                     </div>
+                </section>
 
-                    {/* Action Buttons */}
-                    <div className="flex flex-col sm:flex-row gap-4 pt-6 border-t border-slate-200 dark:border-slate-700">
-                        <button
-                            type="submit"
-                            className="flex-1 bg-gradient-to-r from-blue-600 to-blue-700 hover:from-blue-700 hover:to-blue-800 text-white font-semibold py-3 px-6 rounded-xl transition-all duration-200 transform hover:scale-105 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 shadow-lg"
-                        >
-                            <span className="flex items-center justify-center">
-                                <svg className="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                                </svg>
-                                {isEdit ? 'Update Program' : 'Simpan Program'}
-                            </span>
-                        </button>
-
-                        {data.photos.length > 0 && (
-                            <button
-                                type="button"
-                                onClick={() => {
-                                    document.querySelector('form')?.dispatchEvent(new Event('submit', { cancelable: true, bubbles: true }));
-                                }}
-                                className="flex-1 bg-gradient-to-r from-green-600 to-green-700 hover:from-green-700 hover:to-green-800 text-white font-semibold py-3 px-6 rounded-xl transition-all duration-200 transform hover:scale-105 focus:ring-2 focus:ring-green-500 focus:ring-offset-2 shadow-lg"
-                            >
-                                <span className="flex items-center justify-center">
-                                    <svg className="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12" />
-                                    </svg>
-                                    Upload & Simpan ({data.photos.length} foto)
-                                </span>
-                            </button>
-                        )}
+                <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-800">
+                    <div className="mb-4 flex flex-col gap-2">
+                        <h2 className="text-lg font-semibold text-slate-900 dark:text-white">Kontak &amp; Penerbitan</h2>
+                        <p className="text-sm text-slate-500 dark:text-slate-400">Atur kontak penanggung jawab, tautan pendaftaran, status publikasi, dan metadata SEO.</p>
                     </div>
-                </form>
-            </div>
+                    <div className="grid gap-4 md:grid-cols-2">
+                        <div>
+                            <label className="block text-sm font-medium text-slate-700 dark:text-slate-300">Kontak Person</label>
+                            <input
+                                value={data.contact_person}
+                                onChange={(event) => setData('contact_person', event.target.value)}
+                                placeholder="Nama & nomor yang dapat dihubungi"
+                                className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
+                            />
+                            {errors.contact_person ? <p className="mt-1 text-xs text-rose-500">{errors.contact_person}</p> : null}
+                        </div>
+                        <div>
+                            <label className="block text-sm font-medium text-slate-700 dark:text-slate-300">CTA URL</label>
+                            <input
+                                value={data.cta_url}
+                                onChange={(event) => setData('cta_url', event.target.value)}
+                                placeholder="https://..."
+                                className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
+                            />
+                            {errors.cta_url ? <p className="mt-1 text-xs text-rose-500">{errors.cta_url}</p> : null}
+                        </div>
+                        <div>
+                            <label className="block text-sm font-medium text-slate-700 dark:text-slate-300">Status</label>
+                            <select
+                                value={data.status}
+                                onChange={(event) => setData('status', event.target.value as ProgramStatus)}
+                                className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
+                            >
+                                {STATUS_OPTIONS.map((option) => (
+                                    <option key={option.value} value={option.value}>
+                                        {option.label}
+                                    </option>
+                                ))}
+                            </select>
+                            {errors.status ? <p className="mt-1 text-xs text-rose-500">{errors.status}</p> : null}
+                        </div>
+                        <div>
+                            <label className="block text-sm font-medium text-slate-700 dark:text-slate-300">Jadwal Publikasi</label>
+                            <input
+                                type="datetime-local"
+                                value={data.published_at}
+                                onChange={(event) => setData('published_at', event.target.value)}
+                                className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
+                            />
+                            {errors.published_at ? <p className="mt-1 text-xs text-rose-500">{errors.published_at}</p> : null}
+                        </div>
+                        <div className="md:col-span-2 grid gap-4 md:grid-cols-2">
+                            <div>
+                                <label className="block text-sm font-medium text-slate-700 dark:text-slate-300">Judul SEO</label>
+                                <input
+                                    value={data.seo_title}
+                                    onChange={(event) => setData('seo_title', event.target.value)}
+                                    className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
+                                />
+                                {errors.seo_title ? <p className="mt-1 text-xs text-rose-500">{errors.seo_title}</p> : null}
+                            </div>
+                            <div>
+                                <label className="block text-sm font-medium text-slate-700 dark:text-slate-300">Deskripsi SEO</label>
+                                <textarea
+                                    value={data.seo_description}
+                                    onChange={(event) => setData('seo_description', event.target.value)}
+                                    rows={3}
+                                    className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
+                                />
+                                {errors.seo_description ? <p className="mt-1 text-xs text-rose-500">{errors.seo_description}</p> : null}
+                            </div>
+                        </div>
+                        <div className="md:col-span-2">
+                            <label className="block text-sm font-medium text-slate-700 dark:text-slate-300">Deskripsi Lengkap</label>
+                            <textarea
+                                value={data.description}
+                                onChange={(event) => setData('description', event.target.value)}
+                                rows={10}
+                                className="mt-1 w-full rounded-2xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
+                                placeholder="Detail lengkap kurikulum, metode, dan dukungan program."
+                            />
+                            {errors.description ? <p className="mt-1 text-xs text-rose-500">{errors.description}</p> : null}
+                        </div>
+                    </div>
+                </section>
+
+                <div className="flex items-center justify-end gap-2">
+                    <a
+                        href="/admin/vocational-programs"
+                        className="rounded-xl border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:bg-slate-100 dark:border-slate-600 dark:bg-slate-800 dark:text-white"
+                    >
+                        Batal
+                    </a>
+                    <button
+                        type="submit"
+                        disabled={processing}
+                        className="rounded-xl bg-slate-900 px-5 py-2 text-sm font-semibold text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-slate-700 dark:hover:bg-slate-600"
+                    >
+                        {processing ? 'Menyimpan...' : 'Simpan'}
+                    </button>
+                </div>
+            </form>
+            {toastMessage ? <Toast message={toastMessage} /> : null}
         </AdminLayout>
     );
 }

--- a/resources/js/pages/agenda/Detail.tsx
+++ b/resources/js/pages/agenda/Detail.tsx
@@ -1,13 +1,14 @@
-import { Head, usePage } from '@inertiajs/react';
+import { Head, Link, usePage } from '@inertiajs/react';
+import { ArrowLeft, CalendarCheck, CalendarClock, MapPin, Share2 } from 'lucide-react';
 import AppShell from '@/layouts/AppShell';
 import Breadcrumbs from '@/components/ui/Breadcrumbs';
 import type { EventSummary } from '@/features/content/types';
 
-interface AgendaDetailProps {
+type AgendaDetailProps = {
     event: EventSummary & {
         description?: string | null;
     };
-}
+};
 
 type PageProps = {
     settings?: {
@@ -15,20 +16,77 @@ type PageProps = {
     };
 };
 
-function formatDate(date: string, withTime = true) {
-    const d = new Date(date);
-    const dateStr = d.toLocaleDateString('id-ID', {
-        day: '2-digit',
-        month: 'long',
-        year: 'numeric',
-    });
-
-    if (!withTime) {
-        return dateStr;
+function parseDate(value?: string | null) {
+    if (!value) {
+        return null;
     }
 
-    const timeStr = d.toLocaleTimeString('id-ID', { hour: '2-digit', minute: '2-digit' });
-    return `${dateStr} - ${timeStr}`;
+    const parsed = new Date(value);
+    if (Number.isNaN(parsed.getTime())) {
+        return null;
+    }
+
+    return parsed;
+}
+
+function formatDate(value?: Date | null, options?: Intl.DateTimeFormatOptions) {
+    if (!value) {
+        return null;
+    }
+
+    return new Intl.DateTimeFormat(
+        'id-ID',
+        options ?? {
+            day: '2-digit',
+            month: 'long',
+            year: 'numeric',
+        },
+    ).format(value);
+}
+
+function formatDateRange(startValue?: Date | null, endValue?: Date | null) {
+    if (!startValue && !endValue) {
+        return 'Jadwal menyesuaikan';
+    }
+
+    if (!startValue) {
+        return `Hingga ${formatDate(endValue)}`;
+    }
+
+    if (!endValue) {
+        return `${formatDate(startValue)} • ${formatDate(startValue, { hour: '2-digit', minute: '2-digit' })} WIB`;
+    }
+
+    const sameDay = startValue.toDateString() === endValue.toDateString();
+    if (sameDay) {
+        return `${formatDate(startValue)} • ${formatDate(startValue, {
+            hour: '2-digit',
+            minute: '2-digit',
+        })} - ${formatDate(endValue, { hour: '2-digit', minute: '2-digit' })} WIB`;
+    }
+
+    return `${formatDate(startValue)} → ${formatDate(endValue)}`;
+}
+
+function relativeLabel(startValue?: Date | null) {
+    if (!startValue) {
+        return 'Jadwal segera diumumkan';
+    }
+
+    const now = new Date();
+    const diff = startValue.getTime() - now.getTime();
+    const dayMs = 1000 * 60 * 60 * 24;
+    const days = Math.round(diff / dayMs);
+
+    if (Math.abs(diff) < dayMs / 2) {
+        return diff >= 0 ? 'Berlangsung hari ini' : 'Selesai hari ini';
+    }
+
+    if (days > 0) {
+        return `Dalam ${days} hari`;
+    }
+
+    return `${Math.abs(days)} hari lalu`;
 }
 
 function formatICSDate(date: string) {
@@ -40,9 +98,29 @@ function escapeICS(value: string) {
     return value.replace(/[\\,\n;]/g, (match) => ({ '\\': '\\\\', ',': '\\,', ';': '\\;', '\n': '\\n' }[match] ?? match));
 }
 
+function stripHtml(value?: string | null) {
+    if (!value) {
+        return '';
+    }
+
+    return value.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
+function truncate(value: string, maxLength = 200) {
+    if (value.length <= maxLength) {
+        return value;
+    }
+
+    return `${value.slice(0, maxLength).trim()}…`;
+}
+
 export default function AgendaDetail({ event }: AgendaDetailProps) {
     const { props } = usePage<PageProps>();
     const siteName = props?.settings?.site_name ?? 'SMK Negeri 10 Kuningan';
+    const startDate = parseDate(event.start_at);
+    const endDate = parseDate(event.end_at ?? undefined);
+    const cleanedDescription = truncate(stripHtml(event.description) || event.title, 200);
+
     const eventJsonLd = {
         '@context': 'https://schema.org',
         '@type': 'Event',
@@ -55,7 +133,7 @@ export default function AgendaDetail({ event }: AgendaDetailProps) {
                   name: event.location,
               }
             : undefined,
-        description: event.description ?? undefined,
+        description: stripHtml(event.description) || undefined,
     };
 
     const icsLines = [
@@ -70,7 +148,7 @@ export default function AgendaDetail({ event }: AgendaDetailProps) {
         `SUMMARY:${escapeICS(event.title)}`,
         event.location ? `LOCATION:${escapeICS(event.location)}` : null,
         event.description
-            ? `DESCRIPTION:${escapeICS(event.description.replace(/<[^>]+>/g, ''))}`
+            ? `DESCRIPTION:${escapeICS(stripHtml(event.description))}`
             : null,
         'END:VEVENT',
         'END:VCALENDAR',
@@ -82,42 +160,117 @@ export default function AgendaDetail({ event }: AgendaDetailProps) {
     return (
         <AppShell siteName={siteName}>
             <Head title={`${event.title} - ${siteName}`}>
-                <meta name="description" content={event.description ?? event.title} />
+                <meta name="description" content={cleanedDescription} />
                 <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(eventJsonLd) }} />
             </Head>
 
-            <section className="bg-white">
-                <div className="mx-auto w-full max-w-6xl px-4 py-10">
+            <section className="relative overflow-hidden bg-gradient-to-b from-slate-900 via-slate-900 to-slate-800 text-white">
+                <div className="pointer-events-none absolute inset-0 opacity-50">
+                    <div className="absolute -left-24 top-24 h-56 w-56 rounded-full bg-amber-400/30 blur-3xl" />
+                    <div className="absolute -right-16 bottom-16 h-64 w-64 rounded-full bg-sky-500/20 blur-3xl" />
+                </div>
+                <div className="relative mx-auto w-full max-w-4xl px-4 pb-16 pt-14 lg:pt-20">
                     <Breadcrumbs
                         items={[
                             { label: 'Agenda', href: '/agenda' },
                             { label: event.title },
                         ]}
+                        variant="dark"
+                        className="text-slate-200"
                     />
-                    <header className="mt-4 border-b-4 border-[#1b57d6] pb-3">
-                        <h1 className="text-xl font-semibold uppercase tracking-[0.2em] text-[#1b57d6]">{event.title}</h1>
-                    </header>
-                    <div className="mt-4 flex flex-wrap gap-4 text-sm text-slate-600">
-                        <span>{formatDate(event.start_at)}</span>
-                        {event.end_at ? <span>sampai {formatDate(event.end_at)}</span> : null}
-                        {event.location ? <span>Lokasi: {event.location}</span> : null}
-                    </div>
-                    <div className="mt-4 flex flex-wrap gap-3">
-                        <a
-                            href={icsHref}
-                            download={`${event.slug}.ics`}
-                            className="inline-flex items-center gap-2 rounded-full bg-amber-400 px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-[#0b2b7a]"
+                    <header className="mt-10 space-y-6">
+                        <Link
+                            href="/agenda"
+                            className="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.3em] text-amber-200 transition hover:text-white"
                         >
-                            Tambah ke Kalender (.ics)
-                        </a>
-                    </div>
-                    <div className="mt-6 rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+                            <ArrowLeft className="h-3.5 w-3.5" /> Kembali ke Agenda
+                        </Link>
+                        <div className="space-y-4">
+                            <p className="text-xs font-semibold uppercase tracking-[0.35em] text-amber-200">Agenda Sekolah</p>
+                            <h1 className="text-3xl font-semibold leading-tight sm:text-4xl">{event.title}</h1>
+                            <p className="max-w-3xl text-base text-slate-100 sm:text-lg">
+                                {cleanedDescription || `Agenda resmi ${siteName} untuk mendukung pembelajaran vokasional.`}
+                            </p>
+                        </div>
+                        <div className="grid gap-4 rounded-3xl border border-white/10 bg-white/5 p-6 backdrop-blur sm:grid-cols-2">
+                            <div className="space-y-2">
+                                <p className="text-xs uppercase tracking-[0.3em] text-slate-200">Waktu Pelaksanaan</p>
+                                <p className="text-base font-semibold text-white">{formatDateRange(startDate, endDate)}</p>
+                                <p className="text-xs text-slate-200/70">{relativeLabel(startDate)}</p>
+                            </div>
+                            <div className="space-y-2">
+                                <p className="text-xs uppercase tracking-[0.3em] text-slate-200">Lokasi</p>
+                                <p className="text-base font-semibold text-white">{event.location ?? 'Lokasi menyusul'}</p>
+                                <p className="text-xs text-slate-200/70">Hubungi panitia untuk informasi akses.</p>
+                            </div>
+                        </div>
+                        <div className="flex flex-wrap gap-3">
+                            <a
+                                href={icsHref}
+                                download={`${event.slug}.ics`}
+                                className="inline-flex items-center gap-2 rounded-full bg-amber-400 px-4 py-2 text-xs font-semibold uppercase tracking-[0.28em] text-[#0b2b7a] transition hover:bg-amber-300"
+                            >
+                                <CalendarCheck className="h-4 w-4" /> Simpan ke Kalender (.ics)
+                            </a>
+                            <a
+                                href={`https://calendar.google.com/calendar/render?action=TEMPLATE&text=${encodeURIComponent(event.title)}&dates=${formatICSDate(event.start_at)}${event.end_at ? `/${formatICSDate(event.end_at)}` : ''}&details=${encodeURIComponent(stripHtml(event.description) || '')}&location=${encodeURIComponent(event.location ?? '')}`}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="inline-flex items-center gap-2 rounded-full border border-white/30 bg-white/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.28em] text-white transition hover:border-white hover:bg-white hover:text-slate-900"
+                            >
+                                <Share2 className="h-4 w-4" /> Tambah ke Google Calendar
+                            </a>
+                        </div>
+                    </header>
+                </div>
+            </section>
+
+            <section className="bg-slate-50 py-16">
+                <div className="mx-auto grid w-full max-w-6xl gap-10 px-4 lg:grid-cols-[1.6fr_1fr]">
+                    <article className="rounded-3xl border border-slate-200 bg-white p-8 shadow-sm">
                         {event.description ? (
-                            <div dangerouslySetInnerHTML={{ __html: event.description }} />
+                            <div className="prose max-w-none prose-headings:text-slate-900 prose-p:text-slate-700 prose-ul:list-disc prose-ol:list-decimal prose-li:marker:text-[#1b57d6]">
+                                <div dangerouslySetInnerHTML={{ __html: event.description }} />
+                            </div>
                         ) : (
-                            <p>Deskripsi agenda belum tersedia.</p>
+                            <p className="text-sm text-slate-600">Deskripsi agenda belum tersedia.</p>
                         )}
-                    </div>
+                    </article>
+                    <aside className="space-y-6">
+                        <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+                            <p className="text-xs font-semibold uppercase tracking-[0.35em] text-[#1b57d6]">Informasi Singkat</p>
+                            <dl className="mt-4 space-y-4 text-sm text-slate-600">
+                                <div className="flex items-start gap-3">
+                                    <CalendarClock className="mt-0.5 h-5 w-5 flex-shrink-0 text-[#1b57d6]" />
+                                    <div>
+                                        <dt className="text-xs uppercase tracking-[0.28em] text-slate-500">Waktu</dt>
+                                        <dd className="font-semibold text-slate-900">{formatDateRange(startDate, endDate)}</dd>
+                                    </div>
+                                </div>
+                                <div className="flex items-start gap-3">
+                                    <MapPin className="mt-0.5 h-5 w-5 flex-shrink-0 text-[#1b57d6]" />
+                                    <div>
+                                        <dt className="text-xs uppercase tracking-[0.28em] text-slate-500">Lokasi</dt>
+                                        <dd className="font-semibold text-slate-900">{event.location ?? 'Lokasi menyusul'}</dd>
+                                    </div>
+                                </div>
+                            </dl>
+                        </div>
+                        <div className="rounded-3xl border border-dashed border-slate-300 bg-slate-100/60 p-6 text-sm text-slate-600">
+                            <p className="font-semibold text-slate-800">Butuh dukungan publikasi?</p>
+                            <p className="mt-2">
+                                Hubungi tim humas {siteName} melalui email
+                                {' '}
+                                <a
+                                    href="mailto:halo@smkn10kuningan.sch.id"
+                                    className="text-[#1b57d6] underline decoration-dotted underline-offset-4"
+                                >
+                                    halo@smkn10kuningan.sch.id
+                                </a>
+                                {' '}untuk koordinasi dokumentasi atau peliputan agenda.
+                            </p>
+                        </div>
+                    </aside>
                 </div>
             </section>
         </AppShell>

--- a/resources/js/pages/agenda/Index.tsx
+++ b/resources/js/pages/agenda/Index.tsx
@@ -1,16 +1,24 @@
-import { Head, router, usePage } from '@inertiajs/react';
+import { Head, Link, router, usePage } from '@inertiajs/react';
+import {
+    ArrowRight,
+    CalendarCheck,
+    CalendarClock,
+    CalendarDays,
+    MapPin,
+    Sparkles,
+} from 'lucide-react';
 import AppShell from '@/layouts/AppShell';
 import Breadcrumbs from '@/components/ui/Breadcrumbs';
 import Pagination from '@/components/ui/Pagination';
 import type { EventSummary } from '@/features/content/types';
 import type { Paginated } from '@/features/common/types';
 
-interface AgendaIndexProps {
+type AgendaIndexProps = {
     events: Paginated<EventSummary>;
     filters: {
         filter: string;
     };
-}
+};
 
 type PageProps = {
     settings?: {
@@ -18,118 +26,405 @@ type PageProps = {
     };
 };
 
-function formatRange(start: string, end?: string | null) {
-    const startDate = new Date(start);
-    const endDate = end ? new Date(end) : undefined;
-    const options: Intl.DateTimeFormatOptions = { day: '2-digit', month: 'long', year: 'numeric' };
-
-    if (!endDate) {
-        return startDate.toLocaleDateString('id-ID', options);
+function parseDate(value?: string | null) {
+    if (!value) {
+        return null;
     }
 
-    const sameDay = startDate.toDateString() === endDate.toDateString();
+    const parsed = new Date(value);
+    if (Number.isNaN(parsed.getTime())) {
+        return null;
+    }
 
+    return parsed;
+}
+
+function formatDateRange(startValue?: Date | null, endValue?: Date | null) {
+    if (!startValue && !endValue) {
+        return 'Jadwal menyesuaikan';
+    }
+
+    const dateFormatter = new Intl.DateTimeFormat('id-ID', {
+        day: '2-digit',
+        month: 'long',
+        year: 'numeric',
+    });
+
+    const timeFormatter = new Intl.DateTimeFormat('id-ID', {
+        hour: '2-digit',
+        minute: '2-digit',
+    });
+
+    if (!startValue) {
+        return `Hingga ${dateFormatter.format(endValue!)}`;
+    }
+
+    if (!endValue) {
+        return `${dateFormatter.format(startValue)} • ${timeFormatter.format(startValue)} WIB`;
+    }
+
+    const sameDay = startValue.toDateString() === endValue.toDateString();
     if (sameDay) {
-        const timeOptions: Intl.DateTimeFormatOptions = { hour: '2-digit', minute: '2-digit' };
-        const startTime = startDate.toLocaleTimeString('id-ID', timeOptions);
-        const endTime = endDate.toLocaleTimeString('id-ID', timeOptions);
-        return `${startDate.toLocaleDateString('id-ID', options)} - ${startTime} s/d ${endTime}`;
+        return `${dateFormatter.format(startValue)} • ${timeFormatter.format(startValue)} - ${timeFormatter.format(endValue)} WIB`;
     }
 
-    return `${startDate.toLocaleDateString('id-ID', options)} - ${endDate.toLocaleDateString('id-ID', options)}`;
+    return `${dateFormatter.format(startValue)} → ${dateFormatter.format(endValue)}`;
+}
+
+function relativeLabel(target?: Date | null) {
+    if (!target) {
+        return 'Jadwal segera diumumkan';
+    }
+
+    const now = new Date();
+    const diff = target.getTime() - now.getTime();
+    const dayMs = 1000 * 60 * 60 * 24;
+    const days = Math.round(diff / dayMs);
+
+    if (Math.abs(diff) < dayMs / 2) {
+        return diff >= 0 ? 'Berlangsung hari ini' : 'Selesai hari ini';
+    }
+
+    if (days > 0) {
+        return `Dalam ${days} hari`;
+    }
+
+    return `${Math.abs(days)} hari lalu`;
+}
+
+function stripHtml(value?: string | null) {
+    if (!value) {
+        return '';
+    }
+
+    return value.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
+function truncate(value: string, maxLength = 180) {
+    if (value.length <= maxLength) {
+        return value;
+    }
+
+    return `${value.slice(0, maxLength).trim()}…`;
 }
 
 export default function AgendaIndex({ events, filters }: AgendaIndexProps) {
     const { props } = usePage<PageProps>();
     const siteName = props?.settings?.site_name ?? 'SMK Negeri 10 Kuningan';
     const activeFilter = filters.filter === 'past' ? 'past' : 'upcoming';
+    const listedEvents = events.data ?? [];
+
+    const normalizedEvents = listedEvents.map((event) => ({
+        ...event,
+        startDate: parseDate(event.start_at),
+        endDate: parseDate(event.end_at ?? undefined),
+    }));
+
+    const now = new Date();
+    const highlightEvent =
+        normalizedEvents.find((event) => event.startDate && event.startDate >= now) ?? normalizedEvents[0];
+
+    const highlightDescription = truncate(
+        stripHtml(highlightEvent?.description) ||
+            `Ikuti agenda ${activeFilter === 'past' ? 'arsip' : 'terkini'} dari ${siteName} yang mendukung kolaborasi dan pembelajaran vokasional.`,
+        220,
+    );
+
+    const locations = new Set(
+        normalizedEvents.map((event) => event.location?.trim()).filter((location): location is string => Boolean(location)),
+    );
+
+    const dateExtremes = normalizedEvents.reduce(
+        (acc, event) => {
+            if (event.startDate) {
+                if (!acc.earliest || event.startDate < acc.earliest) {
+                    acc.earliest = event.startDate;
+                }
+                if (!acc.latest || event.startDate > acc.latest) {
+                    acc.latest = event.startDate;
+                }
+            }
+            return acc;
+        },
+        { earliest: null as Date | null, latest: null as Date | null },
+    );
+
+    const coverageLabel =
+        dateExtremes.earliest && dateExtremes.latest
+            ? `${new Intl.DateTimeFormat('id-ID', { month: 'short', year: 'numeric' }).format(dateExtremes.earliest)} — ${new Intl.DateTimeFormat('id-ID', { month: 'short', year: 'numeric' }).format(dateExtremes.latest)}`
+            : 'Menunggu jadwal';
+
+    const metaDescription = highlightDescription || `Agenda kegiatan terbaru dari ${siteName}.`;
 
     return (
         <AppShell siteName={siteName}>
             <Head title={`Agenda - ${siteName}`}>
-                <meta name="description" content={`Agenda kegiatan terbaru dari ${siteName}.`} />
+                <meta name="description" content={metaDescription} />
             </Head>
 
-            <section className="bg-white">
-                <div className="mx-auto w-full max-w-6xl px-4 py-10">
-                    <Breadcrumbs items={[{ label: 'Agenda', href: '/agenda' }]} />
-                    <header className="mt-4 border-b-4 border-[#1b57d6] pb-3">
-                        <h1 className="text-xl font-semibold uppercase tracking-[0.2em] text-[#1b57d6]">Agenda Kegiatan</h1>
-                        <p className="mt-2 text-sm text-slate-600">Jadwal pelatihan, sosialisasi, dan agenda penting lainnya.</p>
-                    </header>
-
-                    <div className="mt-6 flex flex-wrap items-center gap-3">
-                        <button
-                            type="button"
-                            onClick={() => router.get('/agenda', { filter: 'upcoming' }, { preserveState: true, preserveScroll: true })}
-                            className={`rounded-full px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] transition ${
-                                activeFilter === 'upcoming'
-                                    ? 'bg-[#1b57d6] text-white shadow'
-                                    : 'border border-slate-300 text-slate-700 hover:border-[#1b57d6] hover:text-[#1b57d6]'
-                            }`}
-                            aria-pressed={activeFilter === 'upcoming'}
-                        >
-                            Mendatang
-                        </button>
-                        <button
-                            type="button"
-                            onClick={() => router.get('/agenda', { filter: 'past' }, { preserveState: true, preserveScroll: true })}
-                            className={`rounded-full px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] transition ${
-                                activeFilter === 'past'
-                                    ? 'bg-[#1b57d6] text-white shadow'
-                                    : 'border border-slate-300 text-slate-700 hover:border-[#1b57d6] hover:text-[#1b57d6]'
-                            }`}
-                            aria-pressed={activeFilter === 'past'}
-                        >
-                            Selesai
-                        </button>
-                    </div>
-
-                    <div className="mt-6 space-y-4">
-                        {events.data.length ? (
-                            events.data.map((event) => {
-                                const isUpcoming = new Date(event.start_at) >= new Date();
-                                return (
-                                    <article key={event.slug} className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
-                                        <div className="flex flex-wrap items-start justify-between gap-3">
-                                            <div>
-                                                <span className={`inline-block rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] ${
-                                                    isUpcoming ? 'bg-[#1b57d6]/10 text-[#1b57d6]' : 'bg-slate-200 text-slate-600'
-                                                }`}>
-                                                    {isUpcoming ? 'Mendatang' : 'Selesai'}
-                                                </span>
-                                                <h2 className="mt-2 text-lg font-semibold text-slate-900">
-                                                    <a href={`/agenda/${event.slug}`} className="hover:text-[#1b57d6]">
-                                                        {event.title}
-                                                    </a>
-                                                </h2>
-                                            </div>
-                                            <a
-                                                href={`/agenda/${event.slug}`}
-                                                className="rounded-full bg-amber-400 px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-[#0b2b7a]"
-                                            >
-                                                Detail
-                                            </a>
+            <section className="relative overflow-hidden bg-gradient-to-b from-slate-900 via-slate-900 to-slate-800 text-white">
+                <div className="pointer-events-none absolute inset-0 opacity-50">
+                    <div className="absolute -left-24 top-24 h-56 w-56 rounded-full bg-amber-400/30 blur-3xl" />
+                    <div className="absolute -right-16 bottom-16 h-64 w-64 rounded-full bg-sky-500/20 blur-3xl" />
+                </div>
+                <div className="relative mx-auto w-full max-w-6xl px-4 pb-16 pt-14 lg:pt-20">
+                    <Breadcrumbs
+                        items={[{ label: 'Agenda', href: '/agenda' }]}
+                        variant="dark"
+                        className="text-slate-200"
+                    />
+                    <div className="mt-10 grid gap-12 lg:grid-cols-[1.55fr_1fr] lg:items-start">
+                        <header className="space-y-6">
+                            <p className="text-xs font-semibold uppercase tracking-[0.35em] text-amber-200">Agenda Sekolah</p>
+                            <h1 className="text-3xl font-semibold leading-tight sm:text-4xl">
+                                Jadwal Kolaboratif untuk Komunitas {siteName}
+                            </h1>
+                            <p className="max-w-2xl text-base text-slate-100 sm:text-lg">{highlightDescription}</p>
+                            <div className="grid gap-4 sm:grid-cols-3">
+                                <div className="rounded-2xl border border-white/20 bg-white/10 p-4 backdrop-blur">
+                                    <div className="flex items-center gap-3">
+                                        <span className="flex h-10 w-10 items-center justify-center rounded-full bg-amber-400/20 text-amber-100">
+                                            <CalendarDays className="h-5 w-5" />
+                                        </span>
+                                        <div>
+                                            <p className="text-xs uppercase tracking-[0.3em] text-slate-200">Agenda Tercatat</p>
+                                            <p className="text-lg font-semibold text-white">{events.total ?? normalizedEvents.length}</p>
                                         </div>
-                                        <p className="mt-3 text-sm font-medium text-slate-600">{formatRange(event.start_at, event.end_at)}</p>
-                                        {event.location ? (
-                                            <p className="text-sm text-slate-500">Lokasi: {event.location}</p>
-                                        ) : null}
-                                        {event.description ? (
-                                            <p className="mt-3 text-sm text-slate-600">{event.description}</p>
-                                        ) : null}
-                                    </article>
-                                );
-                            })
-                        ) : (
-                            <p className="rounded-3xl border border-dashed border-slate-200 p-6 text-sm text-slate-500">
-                                Belum ada agenda pada kategori ini.
-                            </p>
-                        )}
+                                    </div>
+                                </div>
+                                <div className="rounded-2xl border border-white/20 bg-white/10 p-4 backdrop-blur">
+                                    <div className="flex items-center gap-3">
+                                        <span className="flex h-10 w-10 items-center justify-center rounded-full bg-emerald-400/20 text-emerald-100">
+                                            <CalendarCheck className="h-5 w-5" />
+                                        </span>
+                                        <div>
+                                            <p className="text-xs uppercase tracking-[0.3em] text-slate-200">
+                                                {activeFilter === 'past' ? 'Agenda Selesai' : 'Agenda Mendatang'}
+                                            </p>
+                                            <p className="text-lg font-semibold text-white">
+                                                {normalizedEvents.length > 0 ? normalizedEvents.length : 'Menunggu'}
+                                            </p>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div className="rounded-2xl border border-white/20 bg-white/10 p-4 backdrop-blur">
+                                    <div className="flex items-center gap-3">
+                                        <span className="flex h-10 w-10 items-center justify-center rounded-full bg-sky-400/20 text-sky-100">
+                                            <Sparkles className="h-5 w-5" />
+                                        </span>
+                                        <div>
+                                            <p className="text-xs uppercase tracking-[0.3em] text-slate-200">Cakupan Waktu</p>
+                                            <p className="text-lg font-semibold text-white">{coverageLabel}</p>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </header>
+                        <aside className="space-y-6 rounded-3xl border border-white/10 bg-white/5 p-6 backdrop-blur">
+                            <div className="space-y-4">
+                                <p className="text-xs font-semibold uppercase tracking-[0.35em] text-amber-200">Sorotan Agenda</p>
+                                {highlightEvent ? (
+                                    <div className="space-y-4">
+                                        <div>
+                                            <h2 className="text-xl font-semibold text-white">{highlightEvent.title}</h2>
+                                            <p className="mt-2 text-sm text-slate-100/80">
+                                                {truncate(stripHtml(highlightEvent.description) || 'Agenda pilihan yang sedang difokuskan tim sekolah.', 160)}
+                                            </p>
+                                        </div>
+                                        <dl className="space-y-3 text-sm text-slate-100/90">
+                                            <div className="flex items-start gap-3">
+                                                <CalendarClock className="mt-0.5 h-4 w-4 flex-shrink-0 text-amber-200" />
+                                                <div>
+                                                    <dt className="text-xs uppercase tracking-[0.28em] text-slate-300">Jadwal</dt>
+                                                    <dd className="font-medium text-white">
+                                                        {formatDateRange(highlightEvent.startDate, highlightEvent.endDate)}
+                                                    </dd>
+                                                    <dd className="text-xs text-slate-200/70">{relativeLabel(highlightEvent.startDate)}</dd>
+                                                </div>
+                                            </div>
+                                            <div className="flex items-start gap-3">
+                                                <MapPin className="mt-0.5 h-4 w-4 flex-shrink-0 text-amber-200" />
+                                                <div>
+                                                    <dt className="text-xs uppercase tracking-[0.28em] text-slate-300">Lokasi</dt>
+                                                    <dd className="font-medium text-white">
+                                                        {highlightEvent.location ?? 'Lokasi diumumkan kemudian'}
+                                                    </dd>
+                                                </div>
+                                            </div>
+                                        </dl>
+                                        <Link
+                                            href={`/agenda/${highlightEvent.slug}`}
+                                            className="inline-flex items-center gap-2 rounded-full border border-white/30 bg-white/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.28em] text-white transition hover:border-white hover:bg-white hover:text-slate-900"
+                                        >
+                                            Lihat Agenda
+                                            <ArrowRight className="h-3.5 w-3.5" />
+                                        </Link>
+                                    </div>
+                                ) : (
+                                    <p className="text-sm text-slate-100/80">
+                                        Agenda terbaru sedang disusun. Pantau terus kanal informasi resmi {siteName} untuk pembaruan berikutnya.
+                                    </p>
+                                )}
+                            </div>
+                            <div className="rounded-2xl border border-white/10 bg-white/5 p-4 text-sm text-slate-100/80">
+                                <p className="font-semibold text-white">Butuh pendampingan?</p>
+                                <p className="mt-1">
+                                    Tim layanan kami siap membantu koordinasi agenda atau kolaborasi. Silakan hubungi <a
+                                        className="text-amber-200 underline decoration-dotted underline-offset-4"
+                                        href="mailto:halo@smkn10kuningan.sch.id"
+                                    >halo@smkn10kuningan.sch.id</a>.
+                                </p>
+                            </div>
+                        </aside>
+                    </div>
+                </div>
+            </section>
+
+            <section className="bg-slate-50 py-16">
+                <div className="mx-auto w-full max-w-6xl px-4">
+                    <div className="flex flex-col gap-6 rounded-3xl border border-slate-200 bg-white/80 p-6 shadow-sm backdrop-blur md:flex-row md:items-center md:justify-between">
+                        <div>
+                            <p className="text-xs font-semibold uppercase tracking-[0.35em] text-[#1b57d6]">Filter Agenda</p>
+                            <h2 className="mt-2 text-xl font-semibold text-slate-900">Pilih agenda mendatang atau arsip</h2>
+                            <p className="text-sm text-slate-600">Aktifkan kategori sesuai kebutuhan koordinasi Anda. Semua perubahan akan menjaga posisi gulir halaman.</p>
+                        </div>
+                        <div className="flex flex-wrap gap-3">
+                            <button
+                                type="button"
+                                onClick={() =>
+                                    router.get(
+                                        '/agenda',
+                                        { filter: 'upcoming' },
+                                        { preserveScroll: true, preserveState: true },
+                                    )
+                                }
+                                className={`rounded-full px-4 py-2 text-xs font-semibold uppercase tracking-[0.28em] transition ${
+                                    activeFilter === 'upcoming'
+                                        ? 'bg-[#1b57d6] text-white shadow'
+                                        : 'border border-slate-300 text-slate-700 hover:border-[#1b57d6] hover:text-[#1b57d6]'
+                                }`}
+                                aria-pressed={activeFilter === 'upcoming'}
+                            >
+                                Mendatang
+                            </button>
+                            <button
+                                type="button"
+                                onClick={() =>
+                                    router.get(
+                                        '/agenda',
+                                        { filter: 'past' },
+                                        { preserveScroll: true, preserveState: true },
+                                    )
+                                }
+                                className={`rounded-full px-4 py-2 text-xs font-semibold uppercase tracking-[0.28em] transition ${
+                                    activeFilter === 'past'
+                                        ? 'bg-[#1b57d6] text-white shadow'
+                                        : 'border border-slate-300 text-slate-700 hover:border-[#1b57d6] hover:text-[#1b57d6]'
+                                }`}
+                                aria-pressed={activeFilter === 'past'}
+                            >
+                                Selesai
+                            </button>
+                        </div>
                     </div>
 
-                    <div className="mt-8">
+                    <div className="relative mt-10">
+                        <span className="absolute left-6 top-0 hidden h-full w-px bg-gradient-to-b from-[#1b57d6]/30 via-slate-200 to-transparent sm:block" />
+                        <div className="space-y-6">
+                            {normalizedEvents.length > 0 ? (
+                                normalizedEvents.map((event) => {
+                                    const isPast = event.startDate ? event.startDate < now : false;
+                                    const statusLabel = isPast ? 'Selesai' : 'Mendatang';
+
+                                    return (
+                                        <article
+                                            key={event.slug}
+                                            className="relative rounded-3xl border border-slate-200 bg-white p-6 shadow-sm transition hover:-translate-y-1 hover:shadow-lg sm:pl-16"
+                                        >
+                                            <span className="absolute -left-6 top-8 hidden h-3 w-3 rounded-full border-2 border-white bg-[#1b57d6] sm:block" />
+                                            <div className="flex flex-wrap items-start justify-between gap-4">
+                                                <div>
+                                                    <span
+                                                        className={`inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] ${
+                                                            isPast
+                                                                ? 'bg-slate-200 text-slate-600'
+                                                                : 'bg-[#1b57d6]/10 text-[#1b57d6]'
+                                                        }`}
+                                                    >
+                                                        {statusLabel}
+                                                    </span>
+                                                    <h3 className="mt-3 text-lg font-semibold text-slate-900">
+                                                        <Link href={`/agenda/${event.slug}`} className="hover:text-[#1b57d6]">
+                                                            {event.title}
+                                                        </Link>
+                                                    </h3>
+                                                    <p className="mt-2 text-sm text-slate-600">
+                                                        {truncate(stripHtml(event.description) || 'Detil agenda akan diumumkan menjelang pelaksanaan.', 180)}
+                                                    </p>
+                                                </div>
+                                                <Link
+                                                    href={`/agenda/${event.slug}`}
+                                                    className="inline-flex items-center gap-2 rounded-full bg-amber-400 px-4 py-2 text-xs font-semibold uppercase tracking-[0.28em] text-[#0b2b7a] transition hover:bg-amber-300"
+                                                >
+                                                    Detail
+                                                    <ArrowRight className="h-3.5 w-3.5" />
+                                                </Link>
+                                            </div>
+                                            <div className="mt-4 flex flex-wrap gap-4 text-sm text-slate-600">
+                                                <div className="flex items-center gap-2">
+                                                    <CalendarClock className="h-4 w-4 text-[#1b57d6]" />
+                                                    <span>{formatDateRange(event.startDate, event.endDate)}</span>
+                                                </div>
+                                                <div className="flex items-center gap-2">
+                                                    <MapPin className="h-4 w-4 text-[#1b57d6]" />
+                                                    <span>{event.location ?? 'Lokasi menyusul'}</span>
+                                                </div>
+                                            </div>
+                                        </article>
+                                    );
+                                })
+                            ) : (
+                                <div className="rounded-3xl border border-dashed border-slate-300 bg-white p-8 text-center text-sm text-slate-500">
+                                    <p className="font-semibold text-slate-700">Belum ada agenda pada kategori ini.</p>
+                                    <p className="mt-2 text-slate-500">
+                                        Silakan cek kembali dalam beberapa waktu ke depan atau hubungi tim kami untuk berkoordinasi mengenai kebutuhan agenda baru.
+                                    </p>
+                                    <a
+                                        href="mailto:halo@smkn10kuningan.sch.id"
+                                        className="mt-4 inline-flex items-center gap-2 rounded-full border border-[#1b57d6] px-4 py-2 text-xs font-semibold uppercase tracking-[0.28em] text-[#1b57d6] transition hover:bg-[#1b57d6] hover:text-white"
+                                    >
+                                        Konsultasi Agenda
+                                        <ArrowRight className="h-3.5 w-3.5" />
+                                    </a>
+                                </div>
+                            )}
+                        </div>
+                    </div>
+
+                    <div className="mt-10">
                         <Pagination links={events.links} />
+                    </div>
+                </div>
+            </section>
+
+            <section className="bg-white py-16">
+                <div className="mx-auto w-full max-w-6xl px-4">
+                    <div className="grid gap-6 rounded-3xl border border-slate-200 bg-slate-50/80 p-6 shadow-sm sm:grid-cols-3">
+                        <div className="space-y-2">
+                            <p className="text-xs font-semibold uppercase tracking-[0.35em] text-[#1b57d6]">Jejak Lokasi</p>
+                            <p className="text-xl font-semibold text-slate-900">{locations.size > 0 ? `${locations.size} lokasi` : 'Lokasi menyesuaikan'}</p>
+                            <p className="text-sm text-slate-600">Rangkaian agenda berlangsung di berbagai ruang belajar, mulai dari workshop, aula, hingga mitra industri.</p>
+                        </div>
+                        <div className="space-y-2">
+                            <p className="text-xs font-semibold uppercase tracking-[0.35em] text-[#1b57d6]">Kolaborasi</p>
+                            <p className="text-xl font-semibold text-slate-900">Terbuka untuk komunitas</p>
+                            <p className="text-sm text-slate-600">Guru, siswa, alumni, dan mitra industri dapat berpartisipasi. Silakan hubungi kami untuk integrasi kegiatan bersama.</p>
+                        </div>
+                        <div className="space-y-2">
+                            <p className="text-xs font-semibold uppercase tracking-[0.35em] text-[#1b57d6]">Dokumentasi</p>
+                            <p className="text-xl font-semibold text-slate-900">Tersedia liputan</p>
+                            <p className="text-sm text-slate-600">Setiap agenda utama didokumentasikan untuk memperkaya pembelajaran dan publikasi sekolah.</p>
+                        </div>
                     </div>
                 </div>
             </section>

--- a/resources/js/pages/gallery/Detail.tsx
+++ b/resources/js/pages/gallery/Detail.tsx
@@ -1,8 +1,12 @@
-import { Head, usePage } from '@inertiajs/react';
+import { Head, Link, usePage } from '@inertiajs/react';
+import { useMemo } from 'react';
+import { ArrowLeft, ArrowUpRight, Camera, ImageIcon } from 'lucide-react';
 import AppShell from '@/layouts/AppShell';
 import Breadcrumbs from '@/components/ui/Breadcrumbs';
-import MediaGallery from '@/components/vocational/MediaGallery';
-import type { AlbumSummary } from '@/features/content/types';
+import AccessibleVideo from '@/components/vocational/AccessibleVideo';
+import Card from '@/components/ui/card';
+import type { AlbumSummary, AlbumMediaSummary } from '@/features/content/types';
+import type { MediaItem } from '@/features/vocational/types';
 
 interface GalleryDetailProps {
     album: AlbumSummary;
@@ -14,10 +18,29 @@ type PageProps = {
     };
 };
 
+const mapToMediaItem = (item: AlbumMediaSummary, albumTitle: string): MediaItem => ({
+    id: item.id,
+    type: item.type,
+    url: item.url,
+    poster: item.poster ?? undefined,
+    caption: item.caption ?? undefined,
+    track_vtt: item.track_vtt ?? undefined,
+    alt: item.caption ?? albumTitle,
+});
+
 export default function GalleryDetail({ album }: GalleryDetailProps) {
     const { props } = usePage<PageProps>();
     const siteName = props?.settings?.site_name ?? 'SMK Negeri 10 Kuningan';
     const description = album.description ?? `Album ${album.title} dari ${siteName}.`;
+    const mediaItems = useMemo(
+        () => (album.media ?? []).map((item) => mapToMediaItem(item, album.title)),
+        [album.media, album.title],
+    );
+    const mediaCount = album.media_count ?? mediaItems.length;
+    const coverImage = album.cover_url ?? mediaItems[0]?.url ?? null;
+    const fallbackSummary =
+        'Album ini merekam proses belajar, kolaborasi lintas pihak, dan momen penting bersama peserta didik di lingkungan sekolah.';
+    const albumSummary = album.description ?? fallbackSummary;
 
     return (
         <AppShell siteName={siteName}>
@@ -25,22 +48,167 @@ export default function GalleryDetail({ album }: GalleryDetailProps) {
                 <meta name="description" content={description} />
             </Head>
 
-            <section className="bg-white">
-                <div className="mx-auto w-full max-w-6xl px-4 py-10">
+            <section className="relative overflow-hidden bg-gradient-to-b from-slate-950 via-slate-900 to-slate-900 text-white">
+                <div className="pointer-events-none absolute inset-0 opacity-40">
+                    <div className="absolute -left-20 top-20 h-64 w-64 rounded-full bg-emerald-400/25 blur-3xl" />
+                    <div className="absolute -right-10 bottom-10 h-56 w-56 rounded-full bg-sky-500/25 blur-3xl" />
+                </div>
+                <div className="relative mx-auto w-full max-w-6xl px-4 pb-16 pt-14 lg:pt-20">
                     <Breadcrumbs
                         items={[
                             { label: 'Galeri', href: '/galeri' },
                             { label: album.title },
                         ]}
+                        variant="dark"
                     />
-                    <header className="mt-4 border-b-4 border-[#1b57d6] pb-3">
-                        <h1 className="text-xl font-semibold uppercase tracking-[0.2em] text-[#1b57d6]">{album.title}</h1>
-                    </header>
-                    {album.description ? (
-                        <p className="mt-4 text-sm text-slate-600">{album.description}</p>
+                    <div className="mt-8 flex flex-wrap items-center gap-4 text-xs text-white/70">
+                        <Link
+                            href="/galeri"
+                            className="inline-flex items-center gap-2 rounded-full border border-white/40 px-4 py-2 font-semibold text-white transition hover:bg-white/10"
+                        >
+                            <ArrowLeft size={14} aria-hidden /> Kembali ke galeri
+                        </Link>
+                        <span className="inline-flex items-center gap-2 rounded-full border border-white/20 px-4 py-2">
+                            <Camera size={14} aria-hidden /> {mediaCount} dokumentasi
+                        </span>
+                    </div>
+                    <div className="mt-10 grid gap-10 lg:grid-cols-[minmax(0,1.2fr)_minmax(0,1fr)] lg:items-start">
+                        <header className="space-y-6">
+                            <p className="text-xs font-semibold uppercase tracking-[0.35em] text-emerald-200">Album Dokumentasi</p>
+                            <h1 className="text-3xl font-semibold leading-tight sm:text-4xl">{album.title}</h1>
+                            <p className="max-w-2xl text-base text-slate-100 sm:text-lg">{albumSummary}</p>
+                            <div className="flex flex-wrap gap-3">
+                                <Link
+                                    href="/kontak"
+                                    className="inline-flex items-center gap-2 rounded-full bg-white px-5 py-2 text-sm font-semibold text-slate-900 transition hover:bg-amber-200"
+                                >
+                                    Kolaborasi dokumentasi
+                                    <ArrowUpRight size={16} aria-hidden />
+                                </Link>
+                                <Link
+                                    href="/agenda"
+                                    className="inline-flex items-center gap-2 rounded-full border border-white/60 px-5 py-2 text-sm font-semibold text-white transition hover:bg-white/10"
+                                >
+                                    Cek agenda terkait
+                                </Link>
+                            </div>
+                        </header>
+                        <aside className="space-y-4 rounded-3xl border border-white/15 bg-white/10 p-6 backdrop-blur">
+                            <p className="text-xs font-semibold uppercase tracking-[0.35em] text-emerald-200">Ikhtisar Album</p>
+                            <div className="space-y-4">
+                                <div className="rounded-2xl border border-white/15 bg-white/5 p-4">
+                                    <p className="text-xs uppercase tracking-[0.25em] text-slate-200">Total Media</p>
+                                    <p className="mt-2 text-2xl font-semibold text-white">{mediaCount}</p>
+                                    <p className="mt-1 text-xs text-slate-200/80">Foto dan video yang siap diakses publik.</p>
+                                </div>
+                                <div className="rounded-2xl border border-white/15 bg-white/5 p-4">
+                                    <p className="text-xs uppercase tracking-[0.25em] text-slate-200">Penggunaan</p>
+                                    <p className="mt-2 text-sm text-slate-100">
+                                        Cocok untuk materi publikasi sekolah, laporan kegiatan, serta inspirasi belajar bagi komunitas.
+                                    </p>
+                                </div>
+                                <Link
+                                    href="/berita"
+                                    className="inline-flex w-full items-center justify-center gap-2 rounded-2xl border border-white/40 px-4 py-3 text-sm font-semibold text-white transition hover:bg-white/10"
+                                >
+                                    Lihat liputan pendukung
+                                    <ArrowUpRight size={16} aria-hidden />
+                                </Link>
+                            </div>
+                        </aside>
+                    </div>
+
+                    {coverImage ? (
+                        <figure className="mt-12 overflow-hidden rounded-[2rem] border border-white/20 bg-white/10">
+                            <img
+                                src={coverImage}
+                                alt={album.title}
+                                className="h-80 w-full object-cover"
+                                loading="lazy"
+                            />
+                        </figure>
                     ) : null}
-                    <div className="mt-6 rounded-3xl border border-slate-200 bg-white p-4 shadow-sm">
-                        <MediaGallery items={album.media ?? []} />
+                </div>
+            </section>
+
+            <section className="bg-white">
+                <div className="mx-auto w-full max-w-6xl px-4 py-16">
+                    <div className="grid gap-10 lg:grid-cols-[minmax(0,1.7fr)_minmax(0,1fr)] lg:items-start">
+                        <div className="space-y-6">
+                            <h2 className="text-2xl font-semibold text-slate-900">Cerita di balik album</h2>
+                            <p className="text-sm text-slate-600">
+                                {album.description
+                                    ? album.description
+                                    : 'Tim dokumentasi merangkum momen-momen bermakna agar warga sekolah dan mitra dapat merasakan atmosfer kegiatan meskipun tidak hadir secara langsung.'}
+                            </p>
+                            <ul className="grid gap-3 text-sm text-slate-600 sm:grid-cols-2">
+                                <li className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3">
+                                    • Setiap dokumentasi sudah melalui kurasi dan verifikasi izin publikasi.
+                                </li>
+                                <li className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3">
+                                    • Konten dapat dimanfaatkan kembali untuk materi promosi dan laporan kegiatan.
+                                </li>
+                                <li className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3">
+                                    • Apabila membutuhkan resolusi lebih tinggi, silakan hubungi pengelola dokumentasi.
+                                </li>
+                                <li className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3">
+                                    • Sertakan kredit {siteName} ketika menggunakan ulang dokumentasi.
+                                </li>
+                            </ul>
+                        </div>
+                        <Card className="rounded-3xl border-slate-200 bg-slate-50 p-8">
+                            <p className="text-xs font-semibold uppercase tracking-[0.35em] text-brand-600">Butuh bantuan?</p>
+                            <p className="mt-4 text-sm text-slate-600">
+                                Hubungi kami untuk akses arsip lengkap, permintaan dokumentasi tambahan, atau pendampingan publikasi.
+                            </p>
+                            <Link
+                                href="/kontak"
+                                className="mt-6 inline-flex w-full items-center justify-center gap-2 rounded-full bg-brand-600 px-5 py-3 text-sm font-semibold text-white transition hover:bg-brand-700"
+                            >
+                                Jadwalkan diskusi
+                                <ArrowUpRight size={18} aria-hidden />
+                            </Link>
+                        </Card>
+                    </div>
+
+                    <div className="mt-12">
+                        {mediaItems.length ? (
+                            <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+                                {mediaItems.map((item) => (
+                                    <figure key={item.id} className="space-y-3">
+                                        {item.type === 'video' ? (
+                                            <AccessibleVideo item={item} />
+                                        ) : (
+                                            <div className="overflow-hidden rounded-3xl border border-slate-200">
+                                                <img
+                                                    src={item.url}
+                                                    alt={item.alt ?? album.title}
+                                                    className="h-56 w-full object-cover"
+                                                    loading="lazy"
+                                                />
+                                            </div>
+                                        )}
+                                        {item.caption ? (
+                                            <figcaption className="text-xs text-slate-500">{item.caption}</figcaption>
+                                        ) : null}
+                                    </figure>
+                                ))}
+                            </div>
+                        ) : (
+                            <div className="flex flex-col items-center gap-3 rounded-3xl border border-dashed border-slate-300 bg-slate-50 p-10 text-center">
+                                <ImageIcon size={32} className="text-slate-400" aria-hidden />
+                                <p className="text-sm text-slate-600">
+                                    Dokumentasi akan segera tersedia. Tim kami sedang melakukan proses kurasi akhir sebelum dipublikasikan.
+                                </p>
+                                <Link
+                                    href="/kontak"
+                                    className="inline-flex items-center gap-2 rounded-full bg-brand-600 px-5 py-2 text-sm font-semibold text-white transition hover:bg-brand-700"
+                                >
+                                    Minta pemberitahuan rilis
+                                    <ArrowUpRight size={16} aria-hidden />
+                                </Link>
+                            </div>
+                        )}
                     </div>
                 </div>
             </section>

--- a/resources/js/pages/gallery/Index.tsx
+++ b/resources/js/pages/gallery/Index.tsx
@@ -1,8 +1,9 @@
-import { Head, usePage } from '@inertiajs/react';
+import { Head, Link, usePage } from '@inertiajs/react';
+import { ArrowUpRight, Camera, ImageIcon } from 'lucide-react';
 import AppShell from '@/layouts/AppShell';
-import AlbumPreview from '@/components/home/AlbumPreview';
 import Breadcrumbs from '@/components/ui/Breadcrumbs';
 import Pagination from '@/components/ui/Pagination';
+import Card, { CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import type { AlbumSummary } from '@/features/content/types';
 import type { Paginated } from '@/features/common/types';
 
@@ -16,28 +17,247 @@ type PageProps = {
     };
 };
 
+const formatNumber = (value: number) =>
+    new Intl.NumberFormat('id-ID', { maximumFractionDigits: 0 }).format(value);
+
+const getAlbumCover = (album: AlbumSummary) => album.cover_url ?? album.media?.[0]?.url ?? null;
+
 export default function GalleryIndex({ albums }: GalleryIndexProps) {
     const { props } = usePage<PageProps>();
     const siteName = props?.settings?.site_name ?? 'SMK Negeri 10 Kuningan';
+    const albumItems = albums?.data ?? [];
+    const totalAlbums = albums?.total ?? albumItems.length;
+    const totalMedia = albumItems.reduce(
+        (total, album) => total + (album.media_count ?? album.media?.length ?? 0),
+        0,
+    );
+    const averagePerAlbum = albumItems.length ? Math.round(totalMedia / albumItems.length) : 0;
+    const highlightedAlbums = albumItems.slice(0, 3);
+
+    const description = `Kurasi dokumentasi kegiatan ${siteName} untuk merekam proses belajar, kolaborasi, dan karya terbaik.`;
 
     return (
         <AppShell siteName={siteName}>
             <Head title={`Galeri - ${siteName}`}>
-                <meta name="description" content={`Galeri foto dan dokumentasi kegiatan ${siteName}.`} />
+                <meta name="description" content={description} />
             </Head>
 
-            <section className="bg-white">
-                <div className="mx-auto w-full max-w-6xl px-4 py-10">
-                    <Breadcrumbs items={[{ label: 'Galeri', href: '/galeri' }]} />
-                    <header className="mt-4 border-b-4 border-[#1b57d6] pb-3">
-                        <h1 className="text-xl font-semibold uppercase tracking-[0.2em] text-[#1b57d6]">Galeri Kegiatan</h1>
-                        <p className="mt-2 text-sm text-slate-600">Dokumentasi visual dari kelas, workshop, dan karya peserta vokasional.</p>
-                    </header>
-                    <div className="mt-6 rounded-3xl border border-slate-200 bg-white p-4 shadow-sm">
-                        <AlbumPreview items={albums.data} />
+            <section className="relative overflow-hidden bg-gradient-to-b from-slate-950 via-slate-900 to-slate-900 text-white">
+                <div className="pointer-events-none absolute inset-0 opacity-40">
+                    <div className="absolute -left-32 top-0 h-60 w-60 rounded-full bg-sky-500/30 blur-3xl" />
+                    <div className="absolute -right-10 bottom-10 h-56 w-56 rounded-full bg-emerald-400/20 blur-3xl" />
+                </div>
+                <div className="relative mx-auto w-full max-w-6xl px-4 pb-20 pt-14 lg:pt-20">
+                    <Breadcrumbs items={[{ label: 'Galeri', href: '/galeri' }]} variant="dark" />
+                    <div className="mt-10 grid gap-12 lg:grid-cols-[minmax(0,1.35fr)_minmax(0,1fr)] lg:items-start">
+                        <header className="space-y-6">
+                            <p className="text-xs font-semibold uppercase tracking-[0.35em] text-emerald-200">Dokumentasi Sekolah</p>
+                            <h1 className="text-3xl font-semibold leading-tight sm:text-4xl">Galeri {siteName}</h1>
+                            <p className="max-w-2xl text-base text-slate-100 sm:text-lg">
+                                {description}
+                            </p>
+                            <div className="flex flex-wrap gap-3">
+                                <Link
+                                    href="/kontak"
+                                    className="inline-flex items-center gap-2 rounded-full bg-white px-5 py-2 text-sm font-semibold text-slate-900 transition hover:bg-amber-200"
+                                >
+                                    Ajukan Peliputan Kegiatan
+                                    <ArrowUpRight size={16} aria-hidden />
+                                </Link>
+                                <Link
+                                    href="/berita"
+                                    className="inline-flex items-center gap-2 rounded-full border border-white/60 px-5 py-2 text-sm font-semibold text-white transition hover:bg-white/10"
+                                >
+                                    Baca Liputan Pendukung
+                                </Link>
+                            </div>
+                        </header>
+                        <aside className="space-y-4 rounded-3xl border border-white/15 bg-white/10 p-6 backdrop-blur">
+                            <p className="text-xs font-semibold uppercase tracking-[0.35em] text-emerald-200">Ikhtisar Arsip</p>
+                            <div className="grid gap-4 sm:grid-cols-3 lg:grid-cols-1">
+                                <div className="rounded-2xl border border-white/10 bg-white/5 p-4">
+                                    <p className="text-xs uppercase tracking-[0.25em] text-slate-200">Album Aktif</p>
+                                    <p className="mt-2 text-2xl font-semibold text-white">{formatNumber(totalAlbums)}</p>
+                                    <p className="mt-1 text-xs text-slate-200/80">Total album yang siap diakses masyarakat.</p>
+                                </div>
+                                <div className="rounded-2xl border border-white/10 bg-white/5 p-4">
+                                    <p className="text-xs uppercase tracking-[0.25em] text-slate-200">Media Tersimpan</p>
+                                    <p className="mt-2 text-2xl font-semibold text-white">{formatNumber(totalMedia)}</p>
+                                    <p className="mt-1 text-xs text-slate-200/80">Foto &amp; video pada halaman ini.</p>
+                                </div>
+                                <div className="rounded-2xl border border-white/10 bg-white/5 p-4">
+                                    <p className="text-xs uppercase tracking-[0.25em] text-slate-200">Rata-rata Album</p>
+                                    <p className="mt-2 text-2xl font-semibold text-white">{formatNumber(averagePerAlbum || 0)}</p>
+                                    <p className="mt-1 text-xs text-slate-200/80">Dokumentasi per album (halaman ini).</p>
+                                </div>
+                            </div>
+                        </aside>
                     </div>
-                    <div className="mt-6">
+
+                    {highlightedAlbums.length ? (
+                        <div className="mt-12 grid gap-4 sm:grid-cols-3">
+                            {highlightedAlbums.map((album) => (
+                                <Link
+                                    key={album.slug}
+                                    href={`/galeri/${album.slug}`}
+                                    className="group flex flex-col gap-3 rounded-3xl border border-white/15 bg-white/5 p-4 text-white transition hover:bg-white/10"
+                                >
+                                    <div className="flex items-center gap-3">
+                                        <span className="flex h-10 w-10 items-center justify-center rounded-full bg-white/15">
+                                            <Camera size={18} aria-hidden />
+                                        </span>
+                                        <p className="text-sm font-semibold leading-snug text-white/90 group-hover:text-white">
+                                            {album.title}
+                                        </p>
+                                    </div>
+                                    <p className="text-xs text-white/70 line-clamp-3">
+                                        {album.description ?? 'Sorotan aktivitas terbaru yang kami dokumentasikan.'}
+                                    </p>
+                                    <span className="inline-flex items-center gap-2 text-xs font-semibold text-emerald-200">
+                                        {formatNumber(album.media_count ?? album.media?.length ?? 0)} dokumentasi
+                                        <ArrowUpRight size={14} aria-hidden />
+                                    </span>
+                                </Link>
+                            ))}
+                        </div>
+                    ) : null}
+                </div>
+            </section>
+
+            <section className="bg-white">
+                <div className="mx-auto w-full max-w-6xl px-4 py-16">
+                    <div className="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
+                        <div>
+                            <h2 className="text-2xl font-semibold text-slate-900">Dokumentasi Terbaru</h2>
+                            <p className="mt-2 max-w-2xl text-sm text-slate-600">
+                                Setiap album merangkum perjalanan belajar, kolaborasi lintas pihak, hingga perayaan karya peserta didik.
+                                Gunakan arsip ini untuk memahami ragam pengalaman di {siteName}.
+                            </p>
+                        </div>
+                        <Link
+                            href="/agenda"
+                            className="inline-flex items-center gap-2 self-start rounded-full border border-slate-300 px-5 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-100"
+                        >
+                            Lihat Agenda Terkini
+                            <ArrowUpRight size={16} aria-hidden />
+                        </Link>
+                    </div>
+
+                    {albumItems.length ? (
+                        <div className="mt-10 grid gap-6 lg:grid-cols-3">
+                            {albumItems.map((album) => {
+                                const cover = getAlbumCover(album);
+                                const mediaCount = album.media_count ?? album.media?.length ?? 0;
+                                return (
+                                    <Card
+                                        key={album.slug}
+                                        className="flex h-full flex-col overflow-hidden border-slate-200 transition hover:-translate-y-1 hover:shadow-lg"
+                                    >
+                                        <a href={`/galeri/${album.slug}`} className="block overflow-hidden">
+                                            {cover ? (
+                                                <img
+                                                    src={cover}
+                                                    alt={album.title}
+                                                    className="h-48 w-full object-cover transition duration-300 group-hover:scale-105"
+                                                    loading="lazy"
+                                                />
+                                            ) : (
+                                                <div className="flex h-48 w-full items-center justify-center bg-slate-100 text-slate-400">
+                                                    <ImageIcon size={32} aria-hidden />
+                                                </div>
+                                            )}
+                                        </a>
+                                        <CardHeader className="border-0 pb-0">
+                                            <CardTitle className="text-lg font-semibold text-slate-900">
+                                                <a href={`/galeri/${album.slug}`} className="hover:underline">
+                                                    {album.title}
+                                                </a>
+                                            </CardTitle>
+                                        </CardHeader>
+                                        {album.description ? (
+                                            <CardContent className="pt-3">
+                                                <CardDescription className="line-clamp-4 text-sm text-slate-600">
+                                                    {album.description}
+                                                </CardDescription>
+                                            </CardContent>
+                                        ) : null}
+                                        <CardFooter className="mt-auto flex flex-wrap items-center justify-between gap-3 border-t border-slate-100 text-xs text-slate-500">
+                                            <span className="font-semibold uppercase tracking-[0.2em] text-brand-600">
+                                                {formatNumber(mediaCount)} media
+                                            </span>
+                                            <a
+                                                href={`/galeri/${album.slug}`}
+                                                className="inline-flex items-center gap-2 rounded-full border border-slate-200 px-3 py-1 text-xs font-semibold text-slate-700 transition hover:border-brand-500 hover:bg-brand-50 hover:text-brand-600"
+                                            >
+                                                Lihat Album
+                                                <ArrowUpRight size={14} aria-hidden />
+                                            </a>
+                                        </CardFooter>
+                                    </Card>
+                                );
+                            })}
+                        </div>
+                    ) : (
+                        <div className="mt-10 rounded-3xl border border-dashed border-slate-300 bg-slate-50 p-10 text-center">
+                            <p className="text-lg font-semibold text-slate-700">Belum ada dokumentasi yang dipublikasikan.</p>
+                            <p className="mt-2 text-sm text-slate-500">
+                                Tim sedang mengkurasi album terbaru. Silakan hubungi kami apabila membutuhkan arsip khusus atau
+                                peliputan kegiatan mendatang.
+                            </p>
+                            <Link
+                                href="/kontak"
+                                className="mt-4 inline-flex items-center gap-2 rounded-full bg-brand-600 px-5 py-2 text-sm font-semibold text-white transition hover:bg-brand-700"
+                            >
+                                Hubungi Pengelola Dokumentasi
+                                <ArrowUpRight size={16} aria-hidden />
+                            </Link>
+                        </div>
+                    )}
+
+                    <div className="mt-12">
                         <Pagination links={albums.links} />
+                    </div>
+                </div>
+            </section>
+
+            <section className="bg-slate-50">
+                <div className="mx-auto w-full max-w-6xl px-4 py-16">
+                    <div className="grid gap-8 lg:grid-cols-[minmax(0,1.3fr)_minmax(0,1fr)] lg:items-center">
+                        <div className="space-y-4">
+                            <h3 className="text-2xl font-semibold text-slate-900">Butuh dokumentasi kolaboratif?</h3>
+                            <p className="text-sm text-slate-600">
+                                Tim dokumentasi {siteName} siap mendampingi pelaksanaan kegiatan, menyediakan dokumentasi aksesibel, hingga
+                                membantu publikasi lanjutan di kanal resmi sekolah.
+                            </p>
+                            <ul className="grid gap-3 text-sm text-slate-600 sm:grid-cols-2">
+                                <li className="rounded-2xl border border-slate-200 bg-white px-4 py-3">
+                                    • Pendampingan liputan foto dan video.
+                                </li>
+                                <li className="rounded-2xl border border-slate-200 bg-white px-4 py-3">
+                                    • Konsultasi perizinan publikasi peserta didik.
+                                </li>
+                                <li className="rounded-2xl border border-slate-200 bg-white px-4 py-3">
+                                    • Penyediaan caption aksesibel &amp; narasi.
+                                </li>
+                                <li className="rounded-2xl border border-slate-200 bg-white px-4 py-3">
+                                    • Integrasi dengan agenda &amp; berita sekolah.
+                                </li>
+                            </ul>
+                        </div>
+                        <div className="rounded-3xl border border-slate-200 bg-white p-8 shadow-sm">
+                            <p className="text-xs font-semibold uppercase tracking-[0.35em] text-brand-600">Hubungi Kami</p>
+                            <p className="mt-4 text-sm text-slate-600">
+                                Sampaikan kebutuhan dokumentasi Anda melalui formulir kontak. Tim kami akan menindaklanjuti dalam 2x24 jam
+                                kerja.
+                            </p>
+                            <Link
+                                href="/kontak"
+                                className="mt-6 inline-flex w-full items-center justify-center gap-2 rounded-full bg-brand-600 px-5 py-3 text-sm font-semibold text-white transition hover:bg-brand-700"
+                            >
+                                Buka Formulir Kolaborasi
+                                <ArrowUpRight size={18} aria-hidden />
+                            </Link>
+                        </div>
                     </div>
                 </div>
             </section>

--- a/resources/js/pages/news/Index.tsx
+++ b/resources/js/pages/news/Index.tsx
@@ -1,4 +1,5 @@
-import { Head, usePage } from '@inertiajs/react';
+import { Head, Link, usePage } from '@inertiajs/react';
+import { CalendarDays, Newspaper, Sparkles } from 'lucide-react';
 import AppShell from '@/layouts/AppShell';
 import Breadcrumbs from '@/components/ui/Breadcrumbs';
 import Pagination from '@/components/ui/Pagination';
@@ -15,102 +16,388 @@ type PageProps = {
     };
 };
 
+function parseDate(value?: string | null) {
+    if (!value) {
+        return null;
+    }
+
+    const parsed = new Date(value);
+    if (Number.isNaN(parsed.getTime())) {
+        return null;
+    }
+
+    return parsed;
+}
+
+function formatDate(value?: string | null, options?: Intl.DateTimeFormatOptions) {
+    const parsed = parseDate(value);
+
+    if (!parsed) {
+        return null;
+    }
+
+    return new Intl.DateTimeFormat('id-ID', options ?? {
+        day: '2-digit',
+        month: 'long',
+        year: 'numeric',
+    }).format(parsed);
+}
+
+const stopWords = new Set([
+    'dan',
+    'yang',
+    'untuk',
+    'dari',
+    'pada',
+    'dengan',
+    'para',
+    'serta',
+    'dalam',
+    'akan',
+    'kami',
+    'anda',
+    'oleh',
+    'ini',
+    'itu',
+    'sekolah',
+    'smk',
+    'negeri',
+]);
+
 export default function NewsIndex({ posts }: NewsIndexProps) {
     const { props } = usePage<PageProps>();
     const siteName = props?.settings?.site_name ?? 'SMK Negeri 10 Kuningan';
 
+    const allPosts = posts.data ?? [];
+    const [featuredPost, ...otherPosts] = allPosts;
+    const summaryExcerpt = featuredPost?.excerpt ?? featuredPost?.title ?? `Berita dan artikel terkini dari ${siteName}.`;
+
+    const validDates = allPosts
+        .map((post) => parseDate(post.published_at ?? post.created_at ?? ''))
+        .filter((value): value is Date => Boolean(value));
+
+    const stats = validDates.reduce(
+        (acc, date) => {
+            if (!acc.latest || date > acc.latest) {
+                acc.latest = date;
+            }
+
+            if (!acc.earliest || date < acc.earliest) {
+                acc.earliest = date;
+            }
+
+            acc.months.add(new Intl.DateTimeFormat('id-ID', { month: 'long', year: 'numeric' }).format(date));
+            return acc;
+        },
+        { latest: null as Date | null, earliest: null as Date | null, months: new Set<string>() },
+    );
+
+    const latestLabel = stats.latest ? formatDate(stats.latest.toISOString()) : null;
+    const coverageRangeLabel =
+        stats.earliest && stats.latest
+            ? `${formatDate(stats.earliest.toISOString(), { month: 'short', year: 'numeric' })} - ${formatDate(stats.latest.toISOString(), { month: 'short', year: 'numeric' })}`
+            : null;
+
+    const keywordCounts = new Map<string, number>();
+    allPosts.forEach((post) => {
+        const tokens = `${post.title} ${post.excerpt ?? ''}`
+            .toLowerCase()
+            .replace(/[^a-z0-9\s-]/g, ' ')
+            .split(/\s+/)
+            .map((token) => token.trim())
+            .filter((token) => token.length >= 4 && !stopWords.has(token));
+
+        tokens.forEach((token) => {
+            keywordCounts.set(token, (keywordCounts.get(token) ?? 0) + 1);
+        });
+    });
+
+    const trendingTopics = Array.from(keywordCounts.entries())
+        .sort((a, b) => {
+            if (b[1] === a[1]) {
+                return a[0].localeCompare(b[0]);
+            }
+            return b[1] - a[1];
+        })
+        .slice(0, 6)
+        .map(([token]) => token)
+        .map((token) => token.replace(/\b\w/g, (char) => char.toUpperCase()));
+
+    const fallbackTopics = ['Pembelajaran Inklusif', 'Prestasi Siswa', 'Kemitraan Industri', 'Kegiatan Sekolah'];
+    const topicsToDisplay = trendingTopics.length > 0 ? trendingTopics : fallbackTopics;
+
+    const quickPeekPosts = otherPosts.slice(0, 3);
+
+    const postsForGrid = featuredPost ? otherPosts : allPosts;
+
     return (
         <AppShell siteName={siteName}>
             <Head title={`Berita - ${siteName}`}>
-                <meta name="description" content={`Berita dan artikel terkini dari ${siteName}.`} />
+                <meta name="description" content={summaryExcerpt} />
             </Head>
 
-            <section className="bg-white">
-                <div className="mx-auto w-full max-w-6xl px-4 py-10">
-                    <Breadcrumbs items={[{ label: 'Berita', href: '/berita' }]} />
-                    <header className="mt-4 border-b-4 border-[#1b57d6] pb-3">
-                        <h1 className="text-xl font-semibold uppercase tracking-[0.2em] text-[#1b57d6]">SMK Negeri 10 Kuningan</h1>
-                        <p className="mt-2 text-sm text-slate-600">Where Tomorrow's Leaders Come Together</p>
-                    </header>
-
-                    <div className="mt-6 grid gap-8 lg:grid-cols-[2fr_1fr]">
-                        <div className="space-y-4">
-                            {posts.data.length ? (
-                                posts.data.map((post) => (
-                                    <article
-                                        key={post.slug}
-                                        className="grid gap-4 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm md:grid-cols-[220px_1fr]"
-                                    >
-                                        <div className="relative h-44 rounded-xl bg-slate-200">
-                                            {post.cover_url ? (
-                                                <img src={post.cover_url} alt={post.title} className="h-full w-full rounded-xl object-cover" />
-                                            ) : (
-                                                <div className="flex h-full w-full items-center justify-center text-sm text-slate-500">400 x 250</div>
-                                            )}
+            <section className="relative overflow-hidden bg-gradient-to-b from-slate-900 via-slate-900 to-slate-800 text-white">
+                <div className="pointer-events-none absolute inset-0 opacity-40">
+                    <div className="absolute -left-24 top-16 h-48 w-48 rounded-full bg-amber-400/30 blur-3xl" />
+                    <div className="absolute -right-20 bottom-0 h-64 w-64 rounded-full bg-sky-500/20 blur-3xl" />
+                </div>
+                <div className="relative mx-auto w-full max-w-6xl px-4 pb-16 pt-14 lg:pt-20">
+                    <Breadcrumbs items={[{ label: 'Berita', href: '/berita' }]} variant="dark" className="text-slate-200" />
+                    <div className="mt-10 grid gap-12 lg:grid-cols-[1.45fr_1fr] lg:items-start">
+                        <header className="space-y-6">
+                            <p className="text-xs font-semibold uppercase tracking-[0.35em] text-amber-200">Berita & Cerita</p>
+                            <h1 className="text-3xl font-semibold leading-tight sm:text-4xl">Rangkuman Perjalanan Sekolah</h1>
+                            <p className="max-w-2xl text-base text-slate-100 sm:text-lg">
+                                {summaryExcerpt || `Ikuti kabar terbaru, cerita inspiratif, serta agenda penting dari ${siteName}.`}
+                            </p>
+                            <div className="grid gap-4 sm:grid-cols-3">
+                                <div className="rounded-2xl border border-white/20 bg-white/10 p-4 backdrop-blur">
+                                    <div className="flex items-center gap-3 text-sm text-slate-100/80">
+                                        <span className="flex h-9 w-9 items-center justify-center rounded-full bg-amber-400/20 text-amber-100">
+                                            <Newspaper className="h-5 w-5" />
+                                        </span>
+                                        <div>
+                                            <p className="text-xs uppercase tracking-[0.3em] text-slate-200">Artikel</p>
+                                            <p className="text-lg font-semibold text-white">{posts.total ?? allPosts.length}</p>
                                         </div>
-                                        <div className="space-y-2">
-                                            <h2 className="text-lg font-semibold text-slate-900">
-                                                <a href={`/berita/${post.slug}`} className="hover:text-[#1b57d6]">
-                                                    {post.title}
-                                                </a>
-                                            </h2>
-                                            <p className="text-sm text-slate-600">{post.excerpt}</p>
-                                            <div className="flex items-center justify-between text-xs text-slate-500">
-                                                <span>
-                                                    {new Date(post.published_at ?? post.created_at ?? '').toLocaleDateString('id-ID', {
-                                                        day: '2-digit',
-                                                        month: 'long',
-                                                        year: 'numeric',
-                                                    })}
-                                                </span>
-                                                <a
-                                                    href={`/berita/${post.slug}`}
-                                                    className="inline-flex items-center gap-1 rounded-full bg-amber-400 px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-[#0b2b7a]"
-                                                >
-                                                    Baca
-                                                </a>
-                                            </div>
+                                    </div>
+                                </div>
+                                <div className="rounded-2xl border border-white/20 bg-white/10 p-4 backdrop-blur">
+                                    <div className="flex items-center gap-3 text-sm text-slate-100/80">
+                                        <span className="flex h-9 w-9 items-center justify-center rounded-full bg-emerald-400/20 text-emerald-100">
+                                            <CalendarDays className="h-5 w-5" />
+                                        </span>
+                                        <div>
+                                            <p className="text-xs uppercase tracking-[0.3em] text-slate-200">Liputan Terbaru</p>
+                                            <p className="text-lg font-semibold text-white">{latestLabel ?? 'Segera'}</p>
                                         </div>
-                                    </article>
-                                ))
-                            ) : (
-                                <p className="rounded-2xl border border-slate-200 bg-white p-6 text-sm text-slate-500">
-                                    Belum ada berita yang dipublikasikan.
-                                </p>
-                            )}
-                            <Pagination links={posts.links} />
-                        </div>
-                        <aside className="space-y-4">
-                            <div className="rounded-3xl border border-slate-200 bg-white p-5 shadow-sm">
-                                <h3 className="text-sm font-semibold uppercase tracking-[0.3em] text-slate-600">Kategori Populer</h3>
-                                <div className="mt-3 flex flex-wrap gap-2 text-xs">
-                                    {['Pengumuman', 'Prestasi', 'Event', 'PPDB'].map((tag) => (
-                                        <span key={tag} className="rounded-full bg-[#1b57d6]/10 px-3 py-1 font-semibold text-[#1b57d6]">
-                                            {tag}
+                                    </div>
+                                </div>
+                                <div className="rounded-2xl border border-white/20 bg-white/10 p-4 backdrop-blur">
+                                    <div className="flex items-center gap-3 text-sm text-slate-100/80">
+                                        <span className="flex h-9 w-9 items-center justify-center rounded-full bg-sky-400/20 text-sky-100">
+                                            <Sparkles className="h-5 w-5" />
+                                        </span>
+                                        <div>
+                                            <p className="text-xs uppercase tracking-[0.3em] text-slate-200">Kilas Balik</p>
+                                            <p className="text-lg font-semibold text-white">{coverageRangeLabel ?? 'Menanti Arsip'}</p>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </header>
+                        <aside className="space-y-6 rounded-3xl border border-white/10 bg-white/5 p-6 backdrop-blur">
+                            <div>
+                                <p className="text-xs font-semibold uppercase tracking-[0.35em] text-amber-200">Sorotan Topik</p>
+                                <div className="mt-4 flex flex-wrap gap-2 text-xs font-semibold text-white/90">
+                                    {topicsToDisplay.map((topic) => (
+                                        <span key={topic} className="rounded-full border border-white/20 bg-white/10 px-3 py-1">
+                                            #{topic}
                                         </span>
                                     ))}
                                 </div>
                             </div>
-                            <div className="rounded-3xl border border-slate-200 bg-white p-5 shadow-sm">
-                                <h3 className="text-sm font-semibold uppercase tracking-[0.3em] text-slate-600">Terbaru</h3>
-                                <ul className="mt-3 space-y-3 text-sm text-slate-600">
-                                    {posts.data.slice(0, 5).map((post) => (
-                                        <li key={`recent-${post.slug}`} className="border-b border-dashed border-slate-200 pb-2 last:border-0">
-                                            <a href={`/berita/${post.slug}`} className="font-semibold text-[#1b57d6]">
-                                                {post.title}
-                                            </a>
-                                            <p className="text-xs text-slate-500">
-                                                {new Date(post.published_at ?? post.created_at ?? '').toLocaleDateString('id-ID', {
+                            <div>
+                                <p className="text-xs font-semibold uppercase tracking-[0.35em] text-amber-200">Rentang Peliputan</p>
+                                <p className="mt-3 text-sm text-slate-100">
+                                    {stats.months.size > 0
+                                        ? `Arsip berita mencakup ${stats.months.size} bulan berbeda dengan update terakhir ${latestLabel ?? 'segera hadir'}.`
+                                        : 'Menanti publikasi perdana untuk mengisi arsip berita sekolah.'}
+                                </p>
+                            </div>
+                            <div className="flex flex-wrap gap-3">
+                                <Link
+                                    href="/profil"
+                                    className="inline-flex items-center gap-2 rounded-full bg-white px-5 py-2 text-sm font-semibold text-slate-900 transition hover:bg-amber-200"
+                                >
+                                    Kenali Sekolah Lebih Dekat ↗
+                                </Link>
+                                <Link
+                                    href="/kontak"
+                                    className="inline-flex items-center gap-2 rounded-full border border-white/60 px-5 py-2 text-sm font-semibold text-white transition hover:bg-white/10"
+                                >
+                                    Kolaborasi Peliputan
+                                </Link>
+                            </div>
+                        </aside>
+                    </div>
+                </div>
+            </section>
+
+            <section className="bg-slate-50">
+                <div className="mx-auto w-full max-w-6xl px-4 py-16">
+                    {featuredPost ? (
+                        <div className="grid gap-12 lg:grid-cols-[1.6fr_1fr] lg:items-start">
+                            <article className="overflow-hidden rounded-3xl border border-slate-200 bg-white shadow-sm">
+                                {featuredPost.cover_url ? (
+                                    <div className="relative h-72 w-full bg-slate-200">
+                                        <img
+                                            src={featuredPost.cover_url}
+                                            alt={featuredPost.title}
+                                            className="h-full w-full object-cover"
+                                        />
+                                    </div>
+                                ) : (
+                                    <div className="flex h-72 w-full items-center justify-center bg-slate-100 text-sm text-slate-500">
+                                        Dokumentasi segera menyusul
+                                    </div>
+                                )}
+                                <div className="space-y-4 px-6 pb-8 pt-6">
+                                    <div className="flex flex-wrap items-center gap-3 text-xs uppercase tracking-[0.3em] text-brand-600">
+                                        <span className="rounded-full bg-brand-100 px-3 py-1 text-brand-700">Sorotan Utama</span>
+                                        {formatDate(featuredPost.published_at ?? featuredPost.created_at ?? null, {
+                                            day: '2-digit',
+                                            month: 'long',
+                                            year: 'numeric',
+                                        }) ? (
+                                            <span className="text-slate-500">
+                                                {formatDate(featuredPost.published_at ?? featuredPost.created_at ?? null)}
+                                            </span>
+                                        ) : null}
+                                    </div>
+                                    <h2 className="text-2xl font-semibold text-slate-900">
+                                        <Link href={`/berita/${featuredPost.slug}`} className="transition hover:text-brand-600">
+                                            {featuredPost.title}
+                                        </Link>
+                                    </h2>
+                                    {featuredPost.excerpt ? (
+                                        <p className="text-base text-slate-600">{featuredPost.excerpt}</p>
+                                    ) : null}
+                                    <div className="flex flex-wrap gap-3">
+                                        <Link
+                                            href={`/berita/${featuredPost.slug}`}
+                                            className="inline-flex items-center gap-2 rounded-full bg-brand-600 px-5 py-2 text-sm font-semibold text-white transition hover:bg-brand-700"
+                                        >
+                                            Baca Selengkapnya
+                                        </Link>
+                                        <Link
+                                            href="/agenda"
+                                            className="inline-flex items-center gap-2 rounded-full border border-brand-200 px-5 py-2 text-sm font-semibold text-brand-600 transition hover:bg-brand-50"
+                                        >
+                                            Lihat Agenda Terkait
+                                        </Link>
+                                    </div>
+                                </div>
+                            </article>
+                            <aside className="space-y-6">
+                                <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+                                    <p className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">Sorotan Singkat</p>
+                                    <ul className="mt-4 space-y-4 text-sm text-slate-600">
+                                        {(quickPeekPosts.length > 0 ? quickPeekPosts : allPosts.slice(0, 3)).map((post) => (
+                                            <li key={`quick-${post.slug}`} className="group space-y-1 border-b border-dashed border-slate-200 pb-3 last:border-0 last:pb-0">
+                                                <Link href={`/berita/${post.slug}`} className="block font-semibold text-brand-600 transition group-hover:text-brand-700">
+                                                    {post.title}
+                                                </Link>
+                                                {formatDate(post.published_at ?? post.created_at ?? null, {
                                                     day: '2-digit',
                                                     month: 'short',
                                                     year: 'numeric',
-                                                })}
-                                            </p>
-                                        </li>
-                                    ))}
-                                </ul>
+                                                }) ? (
+                                                    <p className="text-xs text-slate-500">
+                                                        {formatDate(post.published_at ?? post.created_at ?? null, {
+                                                            day: '2-digit',
+                                                            month: 'short',
+                                                            year: 'numeric',
+                                                        })}
+                                                    </p>
+                                                ) : null}
+                                            </li>
+                                        ))}
+                                    </ul>
+                                </div>
+                                <div className="rounded-3xl border border-slate-200 bg-gradient-to-br from-brand-50 via-white to-white p-6 shadow-sm">
+                                    <p className="text-xs font-semibold uppercase tracking-[0.3em] text-brand-600">Butuh Publikasi?</p>
+                                    <p className="mt-3 text-sm text-slate-600">
+                                        Tim redaksi siap mendampingi unit dan komunitas sekolah untuk mendokumentasikan kegiatan penting.
+                                    </p>
+                                    <Link
+                                        href="/kontak"
+                                        className="mt-4 inline-flex items-center gap-2 rounded-full bg-brand-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-brand-700"
+                                    >
+                                        Hubungi Kami
+                                    </Link>
+                                </div>
+                            </aside>
+                        </div>
+                    ) : (
+                        <div className="rounded-3xl border border-dashed border-slate-300 bg-white/70 p-10 text-center text-slate-500">
+                            <h2 className="text-lg font-semibold text-slate-700">Belum ada kabar terbaru</h2>
+                            <p className="mt-3 text-sm">
+                                Tim redaksi sedang menghimpun cerita terbaik. Silakan kembali dalam waktu dekat atau hubungi kami untuk kolaborasi.
+                            </p>
+                            <div className="mt-6 flex justify-center gap-3">
+                                <Link
+                                    href="/profil"
+                                    className="inline-flex items-center gap-2 rounded-full bg-brand-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-brand-700"
+                                >
+                                    Telusuri Profil Sekolah
+                                </Link>
+                                <Link
+                                    href="/kontak"
+                                    className="inline-flex items-center gap-2 rounded-full border border-brand-200 px-4 py-2 text-sm font-semibold text-brand-600 transition hover:bg-brand-50"
+                                >
+                                    Ajukan Publikasi
+                                </Link>
                             </div>
-                        </aside>
+                        </div>
+                    )}
+
+                    {postsForGrid.length > 0 ? (
+                        <div className="mt-16 space-y-6">
+                            <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+                                <div>
+                                    <h3 className="text-2xl font-semibold text-slate-900">Artikel Terbaru</h3>
+                                    <p className="text-sm text-slate-600">Kumpulan kabar yang siap dibagikan ke komunitas sekolah.</p>
+                                </div>
+                                <Link
+                                    href="/agenda"
+                                    className="inline-flex items-center gap-2 rounded-full border border-slate-200 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-600 transition hover:border-brand-300 hover:text-brand-600"
+                                >
+                                    Lihat Agenda Sekolah
+                                </Link>
+                            </div>
+                            <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+                                {postsForGrid.map((post) => (
+                                    <article key={post.slug} className="flex h-full flex-col rounded-3xl border border-slate-200 bg-white p-5 shadow-sm transition hover:-translate-y-1 hover:shadow-md">
+                                        {post.cover_url ? (
+                                            <div className="mb-4 h-44 overflow-hidden rounded-2xl bg-slate-100">
+                                                <img src={post.cover_url} alt={post.title} className="h-full w-full object-cover transition duration-500 group-hover:scale-105" />
+                                            </div>
+                                        ) : (
+                                            <div className="mb-4 flex h-44 items-center justify-center rounded-2xl border border-dashed border-slate-200 bg-slate-50 text-xs uppercase tracking-[0.3em] text-slate-400">
+                                                Dokumentasi belum tersedia
+                                            </div>
+                                        )}
+                                        <div className="flex flex-1 flex-col">
+                                            {formatDate(post.published_at ?? post.created_at ?? null, {
+                                                day: '2-digit',
+                                                month: 'long',
+                                                year: 'numeric',
+                                            }) ? (
+                                                <p className="text-xs uppercase tracking-[0.3em] text-brand-600">
+                                                    {formatDate(post.published_at ?? post.created_at ?? null)}
+                                                </p>
+                                            ) : null}
+                                            <h4 className="mt-2 text-lg font-semibold text-slate-900">
+                                                <Link href={`/berita/${post.slug}`} className="transition hover:text-brand-600">
+                                                    {post.title}
+                                                </Link>
+                                            </h4>
+                                            {post.excerpt ? <p className="mt-3 text-sm text-slate-600">{post.excerpt}</p> : null}
+                                            <div className="mt-5 flex items-center gap-3 text-xs font-semibold uppercase tracking-[0.3em] text-brand-600">
+                                                <Link href={`/berita/${post.slug}`} className="inline-flex items-center gap-2 rounded-full bg-brand-50 px-3 py-1 text-brand-700 transition hover:bg-brand-100">
+                                                    Baca Artikel ↗
+                                                </Link>
+                                            </div>
+                                        </div>
+                                    </article>
+                                ))}
+                            </div>
+                        </div>
+                    ) : null}
+
+                    <div className="mt-10">
+                        <Pagination links={posts.links} />
                     </div>
                 </div>
             </section>

--- a/resources/js/pages/public/Contact.tsx
+++ b/resources/js/pages/public/Contact.tsx
@@ -1,6 +1,7 @@
-import { useState } from 'react';
-import { Head, router, usePage } from '@inertiajs/react';
+import { useEffect, useMemo, useState } from 'react';
+import { Head, Link, router, usePage } from '@inertiajs/react';
 import AppShell from '@/layouts/AppShell';
+import Breadcrumbs from '@/components/ui/Breadcrumbs';
 
 type FormState = {
     name: string;
@@ -18,109 +19,386 @@ type InertiaPageProps = {
     errors?: Record<string, string>;
     settings?: {
         site_name?: string;
+        school_phone?: string | null;
+        school_email?: string | null;
+        school_address?: string | null;
     };
+};
+
+const initialFormState: FormState = {
+    name: '',
+    email: '',
+    phone: '',
+    message: '',
 };
 
 export default function Contact({ title }: { title: string }) {
     const { props } = usePage<InertiaPageProps>();
     const flash = props?.flash;
     const errors = props?.errors ?? {};
-    const [form, setForm] = useState<FormState>({ name: '', email: '', phone: '', message: '' });
+    const [form, setForm] = useState<FormState>(initialFormState);
+    const [isSubmitting, setIsSubmitting] = useState(false);
+
+    useEffect(() => {
+        if (flash?.success) {
+            setForm({ ...initialFormState });
+        }
+    }, [flash?.success]);
 
     const submit = (event: React.FormEvent<HTMLFormElement>) => {
         event.preventDefault();
-        router.post('/hubungi-kami', form);
+        router.post('/hubungi-kami', form, {
+            preserveScroll: true,
+            onStart: () => setIsSubmitting(true),
+            onFinish: () => setIsSubmitting(false),
+        });
     };
 
     const siteName = props?.settings?.site_name ?? 'SMK Negeri 10 Kuningan';
+    const description =
+        'Hubungi tim SMK Negeri 10 Kuningan untuk konsultasi kemitraan, layanan siswa, maupun pertanyaan media kapan pun Anda perlukan.';
+
+    const officeAddress = props?.settings?.school_address?.trim() ||
+        'Jl. Pendidikan No. 11, Desa Kadugede, Kecamatan Kadugede, Kabupaten Kuningan, Jawa Barat';
+    const phoneNumber = props?.settings?.school_phone?.trim() || '0232-123456';
+    const emailAddress = props?.settings?.school_email?.trim() || 'info@profilsekolah.test';
+
+    const contactChannels = [
+        {
+            label: 'Konsultasi Kemitraan',
+            headline: 'Ciptakan program kolaboratif',
+            detail:
+                'Diskusikan peluang praktik kerja, program magang, ataupun dukungan CSR bagi peserta didik bersama tim hubungan industri.',
+            action: {
+                href: 'mailto:' + emailAddress,
+                text: 'Email Tim Industri',
+                isExternal: true,
+            },
+        },
+        {
+            label: 'Layanan Peserta Didik',
+            headline: 'Pendampingan cepat & empatik',
+            detail:
+                'Tim layanan siswa siap membantu kebutuhan administrasi, konseling, dan penyesuaian pembelajaran untuk siswa berkebutuhan khusus.',
+            action: {
+                href: 'tel:' + phoneNumber.replace(/[^\d+]/g, ''),
+                text: 'Hubungi Sekolah',
+                isExternal: true,
+            },
+        },
+        {
+            label: 'Publik & Media',
+            headline: 'Rilis berita & liputan',
+            detail:
+                'Ajukan permintaan data, jadwal wawancara, hingga akses dokumentasi kegiatan terbaru sekolah.',
+            action: {
+                href: '/berita',
+                text: 'Lihat Sorotan Berita',
+            },
+        },
+    ];
+
+    const officeFacts = useMemo(
+        () => [
+            {
+                title: 'Jam Layanan',
+                description: 'Senin - Jumat pukul 08.00 - 16.00 WIB dengan penjadwalan khusus bagi mitra komunitas.',
+            },
+            {
+                title: 'Lokasi',
+                description: officeAddress,
+            },
+            {
+                title: 'Kontak Utama',
+                description: `Telepon ${phoneNumber} · ${emailAddress}`,
+            },
+        ],
+        [officeAddress, phoneNumber, emailAddress],
+    );
+
+    const responseHighlights = [
+        { title: 'Waktu respons rata-rata', value: '< 1 hari kerja', description: 'Pesan yang masuk pada hari kerja akan dijawab maksimal dalam 24 jam.' },
+        { title: 'Saluran layanan aktif', value: '4 kanal', description: 'Telepon, WhatsApp, email, dan pertemuan langsung dapat dipilih sesuai kebutuhan.' },
+        { title: 'Tim pendamping', value: '3 divisi', description: 'Hubungan industri, layanan peserta didik, serta humas sekolah berkoordinasi menangani pesan Anda.' },
+    ];
+
+    const supportMoments = [
+        {
+            title: 'Butuh rekomendasi program untuk siswa?',
+            description:
+                'Kami bantu memilihkan jurusan, menyusun kebutuhan akomodasi pembelajaran, dan merancang dukungan karier jangka panjang.',
+        },
+        {
+            title: 'Mencari mitra pelaksanaan kegiatan?',
+            description:
+                'Tim hubungan industri akan memandu proses penjajakan, penyusunan MoU, hingga monitoring kegiatan bersama mitra.',
+        },
+        {
+            title: 'Ingin liputan kegiatan sekolah?',
+            description:
+                'Humas sekolah menyiapkan data, narasumber, dan dokumentasi agar publikasi berjalan akurat serta inklusif.',
+        },
+    ];
 
     return (
         <AppShell siteName={siteName}>
-            <Head title={`Hubungi Kami - ${siteName}`} />
+            <Head title={`Hubungi Kami - ${siteName}`}>
+                <meta name="description" content={description} />
+            </Head>
+
+            <section className="relative overflow-hidden bg-gradient-to-b from-slate-900 via-slate-900 to-slate-800 text-white">
+                <div className="pointer-events-none absolute inset-0 opacity-40">
+                    <div className="absolute -left-20 top-16 h-48 w-48 rounded-full bg-emerald-400/30 blur-3xl" />
+                    <div className="absolute -right-16 bottom-0 h-56 w-56 rounded-full bg-sky-500/30 blur-3xl" />
+                </div>
+                <div className="relative mx-auto w-full max-w-6xl px-4 pb-16 pt-14 lg:pt-20">
+                    <Breadcrumbs items={[{ label: 'Hubungi Kami', href: '/hubungi-kami' }]} variant="dark" className="text-slate-200" />
+                    <div className="mt-10 grid gap-12 lg:grid-cols-[1.5fr_1fr] lg:items-start">
+                        <header className="space-y-6">
+                            <p className="text-xs font-semibold uppercase tracking-[0.35em] text-emerald-200">Pusat Layanan</p>
+                            <h1 className="text-3xl font-semibold leading-tight sm:text-4xl">{title}</h1>
+                            <p className="max-w-2xl text-base text-slate-100 sm:text-lg">
+                                Kami menyediakan jalur komunikasi yang responsif bagi orang tua, mitra, media, dan komunitas untuk memastikan kebutuhan peserta didik terpenuhi secara menyeluruh.
+                            </p>
+                            <div className="flex flex-wrap gap-3">
+                                <a
+                                    href={`tel:${phoneNumber.replace(/[^\d+]/g, '')}`}
+                                    className="inline-flex items-center gap-2 rounded-full bg-white px-5 py-2 text-sm font-semibold text-slate-900 transition hover:bg-amber-200"
+                                >
+                                    Hubungi via Telepon ↗
+                                </a>
+                                <a
+                                    href={`mailto:${emailAddress}`}
+                                    className="inline-flex items-center gap-2 rounded-full border border-white/70 px-5 py-2 text-sm font-semibold text-white transition hover:bg-white/10"
+                                >
+                                    Kirim Email ke Sekolah
+                                </a>
+                            </div>
+                        </header>
+                        <aside className="space-y-4 rounded-3xl border border-white/20 bg-white/10 p-6 backdrop-blur">
+                            <p className="text-xs font-semibold uppercase tracking-[0.35em] text-emerald-200">Ikhtisar Layanan</p>
+                            <p className="text-sm text-slate-100">
+                                Dapatkan informasi lengkap mengenai jadwal layanan, kanal komunikasi utama, dan koordinasi kunjungan ke kampus.
+                            </p>
+                            <ul className="space-y-3 text-sm text-slate-100/90">
+                                {officeFacts.map((fact) => (
+                                    <li key={fact.title} className="rounded-2xl border border-white/10 bg-white/5 p-3">
+                                        <p className="text-xs font-semibold uppercase tracking-[0.3em] text-emerald-200">{fact.title}</p>
+                                        <p className="mt-2 leading-relaxed">{fact.description}</p>
+                                    </li>
+                                ))}
+                            </ul>
+                        </aside>
+                    </div>
+                    <div className="mt-14 grid gap-6 md:grid-cols-3">
+                        {responseHighlights.map((item) => (
+                            <div key={item.title} className="rounded-3xl border border-white/10 bg-white/5 p-6 text-sm text-slate-100 backdrop-blur">
+                                <p className="text-xs font-semibold uppercase tracking-[0.3em] text-emerald-200">{item.title}</p>
+                                <p className="mt-3 text-2xl font-semibold text-white">{item.value}</p>
+                                <p className="mt-2 leading-relaxed text-slate-100/90">{item.description}</p>
+                            </div>
+                        ))}
+                    </div>
+                </div>
+            </section>
 
             <section className="bg-white">
-                <div className="mx-auto w-full max-w-6xl px-4 py-10">
-                    <header className="border-b-4 border-[#1b57d6] pb-3">
-                        <h1 className="text-xl font-semibold uppercase tracking-[0.2em] text-[#1b57d6]">{title}</h1>
-                        <p className="mt-2 text-sm text-slate-600">Where Tomorrow's Leaders Come Together</p>
-                    </header>
+                <div className="mx-auto w-full max-w-6xl px-4 py-16">
+                    <div className="grid gap-6 lg:grid-cols-3">
+                        {contactChannels.map((channel) => (
+                            <div key={channel.label} className="flex h-full flex-col justify-between rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+                                <div className="space-y-3">
+                                    <p className="text-xs font-semibold uppercase tracking-[0.35em] text-brand-600">{channel.label}</p>
+                                    <h2 className="text-lg font-semibold text-slate-900">{channel.headline}</h2>
+                                    <p className="text-sm text-slate-600">{channel.detail}</p>
+                                </div>
+                                <div className="mt-6">
+                                    {channel.action.isExternal ? (
+                                        <a
+                                            href={channel.action.href}
+                                            className="inline-flex items-center gap-2 rounded-full border border-brand-600 px-4 py-2 text-sm font-semibold text-brand-700 transition hover:bg-brand-50"
+                                        >
+                                            {channel.action.text} ↗
+                                        </a>
+                                    ) : (
+                                        <Link
+                                            href={channel.action.href}
+                                            className="inline-flex items-center gap-2 rounded-full border border-brand-600 px-4 py-2 text-sm font-semibold text-brand-700 transition hover:bg-brand-50"
+                                        >
+                                            {channel.action.text} ↗
+                                        </Link>
+                                    )}
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+                </div>
+            </section>
 
-                    {flash?.success ? (
-                        <div className="mt-6 rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700">
-                            {flash.success}
+            <section className="bg-slate-50">
+                <div className="mx-auto w-full max-w-6xl px-4 py-16">
+                    <div className="grid gap-8 lg:grid-cols-[1.4fr_1fr]">
+                        <div className="rounded-3xl border border-slate-200 bg-white p-8 shadow-sm">
+                            <h2 className="text-2xl font-semibold text-slate-900">Kirim Pesan Langsung</h2>
+                            <p className="mt-3 text-sm text-slate-600">
+                                Tulis kebutuhan Anda sedetail mungkin agar tim kami dapat merespons dengan solusi yang relevan. Kami akan menghubungi Anda melalui kanal pilihan dalam satu hari kerja.
+                            </p>
+
+                            {flash?.success ? (
+                                <div className="mt-6 rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm font-semibold text-emerald-700" role="status">
+                                    {flash.success}
+                                </div>
+                            ) : null}
+
+                            <form onSubmit={submit} className="mt-8 space-y-6">
+                                <div className="grid gap-6 md:grid-cols-2">
+                                    <div>
+                                        <label htmlFor="contact-name" className="text-sm font-semibold text-slate-700">
+                                            Nama Lengkap
+                                        </label>
+                                        <input
+                                            id="contact-name"
+                                            className="mt-2 w-full rounded-xl border border-slate-300 px-4 py-2.5 text-sm focus:border-brand-600 focus:outline-none focus:ring-2 focus:ring-brand-100"
+                                            placeholder="Nama lengkap Anda"
+                                            value={form.name}
+                                            onChange={(event) => setForm((prev) => ({ ...prev, name: event.target.value }))}
+                                            required
+                                        />
+                                        {errors.name ? <p className="mt-2 text-xs text-rose-500">{errors.name}</p> : null}
+                                    </div>
+                                    <div>
+                                        <label htmlFor="contact-phone" className="text-sm font-semibold text-slate-700">
+                                            Nomor Telepon (opsional)
+                                        </label>
+                                        <input
+                                            id="contact-phone"
+                                            className="mt-2 w-full rounded-xl border border-slate-300 px-4 py-2.5 text-sm focus:border-brand-600 focus:outline-none focus:ring-2 focus:ring-brand-100"
+                                            placeholder="08xxxxxxxx"
+                                            value={form.phone}
+                                            onChange={(event) => setForm((prev) => ({ ...prev, phone: event.target.value }))}
+                                        />
+                                        {errors.phone ? <p className="mt-2 text-xs text-rose-500">{errors.phone}</p> : null}
+                                    </div>
+                                </div>
+                                <div className="grid gap-6 md:grid-cols-2">
+                                    <div>
+                                        <label htmlFor="contact-email" className="text-sm font-semibold text-slate-700">
+                                            Email (opsional)
+                                        </label>
+                                        <input
+                                            id="contact-email"
+                                            type="email"
+                                            className="mt-2 w-full rounded-xl border border-slate-300 px-4 py-2.5 text-sm focus:border-brand-600 focus:outline-none focus:ring-2 focus:ring-brand-100"
+                                            placeholder="email@contoh.com"
+                                            value={form.email}
+                                            onChange={(event) => setForm((prev) => ({ ...prev, email: event.target.value }))}
+                                        />
+                                        {errors.email ? <p className="mt-2 text-xs text-rose-500">{errors.email}</p> : null}
+                                    </div>
+                                    <div className="rounded-2xl border border-dashed border-brand-200 bg-brand-50/40 p-4 text-xs text-brand-900">
+                                        <p className="font-semibold uppercase tracking-[0.3em] text-brand-600">Tips Pesan</p>
+                                        <ul className="mt-3 space-y-2 text-[13px] leading-relaxed text-brand-900">
+                                            <li>Sertakan kanal respons pilihan (WhatsApp, email, atau telepon).</li>
+                                            <li>Beritahukan waktu terbaik untuk dihubungi.</li>
+                                            <li>Jika perlu, sebutkan kebutuhan aksesibilitas saat pertemuan.</li>
+                                        </ul>
+                                    </div>
+                                </div>
+                                <div>
+                                    <label htmlFor="contact-message" className="text-sm font-semibold text-slate-700">
+                                        Pesan
+                                    </label>
+                                    <textarea
+                                        id="contact-message"
+                                        className="mt-2 w-full rounded-xl border border-slate-300 px-4 py-3 text-sm focus:border-brand-600 focus:outline-none focus:ring-2 focus:ring-brand-100"
+                                        placeholder="Tulis pesan, kebutuhan, atau pertanyaan Anda"
+                                        rows={6}
+                                        value={form.message}
+                                        onChange={(event) => setForm((prev) => ({ ...prev, message: event.target.value }))}
+                                        required
+                                    />
+                                    {errors.message ? <p className="mt-2 text-xs text-rose-500">{errors.message}</p> : null}
+                                </div>
+                                <div className="flex flex-wrap items-center justify-between gap-4">
+                                    <p className="text-xs text-slate-500">
+                                        Dengan mengirim pesan ini Anda menyetujui kebijakan privasi sekolah dan bersedia dihubungi oleh tim kami.
+                                    </p>
+                                    <button
+                                        className="inline-flex items-center justify-center gap-2 rounded-full bg-brand-600 px-6 py-2.5 text-sm font-semibold uppercase tracking-[0.2em] text-white transition hover:bg-brand-700 disabled:cursor-not-allowed disabled:bg-brand-400"
+                                        type="submit"
+                                        disabled={isSubmitting}
+                                    >
+                                        {isSubmitting ? 'Mengirim...' : 'Kirim Pesan'}
+                                    </button>
+                                </div>
+                            </form>
                         </div>
-                    ) : null}
 
-                    <div className="mt-8 grid gap-8 lg:grid-cols-[1.6fr_1fr]">
-                        <form onSubmit={submit} className="space-y-4 rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
-                            <div>
-                                <label className="text-sm font-semibold text-slate-700">Nama</label>
-                                <input
-                                    className="mt-2 w-full rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-[#1b57d6] focus:outline-none"
-                                    placeholder="Nama lengkap"
-                                    value={form.name}
-                                    onChange={(event) => setForm({ ...form, name: event.target.value })}
-                                    required
-                                />
-                                {errors.name ? <p className="mt-1 text-xs text-rose-500">{errors.name}</p> : null}
-                            </div>
-                            <div className="grid gap-4 md:grid-cols-2">
-                                <div>
-                                    <label className="text-sm font-semibold text-slate-700">Email (opsional)</label>
-                                    <input
-                                        className="mt-2 w-full rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-[#1b57d6] focus:outline-none"
-                                        placeholder="email@contoh.com"
-                                        value={form.email}
-                                        type="email"
-                                        onChange={(event) => setForm({ ...form, email: event.target.value })}
-                                    />
-                                    {errors.email ? <p className="mt-1 text-xs text-rose-500">{errors.email}</p> : null}
+                        <aside className="space-y-6">
+                            <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+                                <p className="text-xs font-semibold uppercase tracking-[0.35em] text-brand-600">Kantor Sekolah</p>
+                                <p className="mt-3 text-sm text-slate-600">
+                                    {officeAddress}
+                                </p>
+                                <div className="mt-4 space-y-2 text-sm text-slate-700">
+                                    <p>
+                                        <span className="font-semibold">Telepon:</span> {phoneNumber}
+                                    </p>
+                                    <p>
+                                        <span className="font-semibold">Email:</span> {emailAddress}
+                                    </p>
+                                    <p>
+                                        <span className="font-semibold">WhatsApp:</span> 0812-3456-7890
+                                    </p>
                                 </div>
-                                <div>
-                                    <label className="text-sm font-semibold text-slate-700">Telepon (opsional)</label>
-                                    <input
-                                        className="mt-2 w-full rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-[#1b57d6] focus:outline-none"
-                                        placeholder="08xxxxxxxx"
-                                        value={form.phone}
-                                        onChange={(event) => setForm({ ...form, phone: event.target.value })}
-                                    />
-                                    {errors.phone ? <p className="mt-1 text-xs text-rose-500">{errors.phone}</p> : null}
+                                <div className="mt-4 space-y-2 text-xs text-slate-500">
+                                    <p>Kunjungan tatap muka disarankan melalui janji temu sebelumnya.</p>
+                                    <p>Area parkir ramah kursi roda tersedia di pintu masuk utama.</p>
                                 </div>
                             </div>
-                            <div>
-                                <label className="text-sm font-semibold text-slate-700">Pesan</label>
-                                <textarea
-                                    className="mt-2 w-full rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-[#1b57d6] focus:outline-none"
-                                    placeholder="Tulis pesan Anda"
-                                    rows={5}
-                                    value={form.message}
-                                    onChange={(event) => setForm({ ...form, message: event.target.value })}
-                                    required
-                                />
-                                {errors.message ? <p className="mt-1 text-xs text-rose-500">{errors.message}</p> : null}
-                            </div>
-                            <div className="flex items-center justify-end">
-                                <button
-                                    className="rounded-full bg-[#1b57d6] px-6 py-2 text-sm font-semibold uppercase tracking-[0.2em] text-white transition hover:bg-[#0f3bb2]"
-                                    type="submit"
+                            <div className="rounded-3xl border border-slate-200 bg-slate-100 p-6 shadow-inner">
+                                <p className="text-xs font-semibold uppercase tracking-[0.35em] text-brand-600">Peta Lokasi</p>
+                                <div className="mt-4 h-48 w-full overflow-hidden rounded-2xl border border-slate-200 bg-slate-200">
+                                    <p className="flex h-full items-center justify-center text-xs text-slate-500">Peta sekolah akan ditampilkan di sini.</p>
+                                </div>
+                                <a
+                                    href="https://maps.google.com/?q=SMK+Negeri+10+Kuningan"
+                                    className="mt-4 inline-flex items-center gap-2 text-sm font-semibold text-brand-700 hover:text-brand-600"
                                 >
-                                    Kirim Pesan
-                                </button>
+                                    Buka di Google Maps ↗
+                                </a>
                             </div>
-                        </form>
-                        <aside className="space-y-4 rounded-3xl border border-slate-200 bg-white p-6 shadow-sm text-sm text-slate-600">
-                            <h2 className="text-sm font-semibold uppercase tracking-[0.3em] text-[#1b57d6]">Kantor Sekolah</h2>
-                            <p>Jl. Pendidikan No. 11, Desa/Kelurahan Kadugede, Kecamatan Kadugede, Kabupaten Kuningan</p>
-                            <div className="space-y-1">
-                                <p>Telepon: <strong>0232 123456</strong></p>
-                                <p>Fax: <strong>0232 123456</strong></p>
-                                <p>Email: <strong>info@profilsekolah.test</strong></p>
-                            </div>
-                            <div className="mt-4 h-48 w-full rounded-md bg-slate-200">
-                                <p className="flex h-full items-center justify-center text-xs text-slate-500">Peta sekolah</p>
-                            </div>
-                            <p className="text-xs text-slate-500">Silakan datang pada hari kerja pukul 08.00 � 16.00 WIB.</p>
                         </aside>
+                    </div>
+                </div>
+            </section>
+
+            <section className="bg-white">
+                <div className="mx-auto w-full max-w-6xl px-4 py-16">
+                    <div className="rounded-3xl border border-slate-200 bg-white p-8 shadow-sm">
+                        <div className="grid gap-8 lg:grid-cols-3">
+                            {supportMoments.map((moment) => (
+                                <div key={moment.title} className="rounded-3xl border border-slate-200 bg-slate-50 p-6 text-sm text-slate-600">
+                                    <p className="text-xs font-semibold uppercase tracking-[0.35em] text-brand-600">Kapan Menghubungi</p>
+                                    <h3 className="mt-3 text-lg font-semibold text-slate-900">{moment.title}</h3>
+                                    <p className="mt-2 leading-relaxed">{moment.description}</p>
+                                </div>
+                            ))}
+                        </div>
+                        <div className="mt-10 flex flex-wrap items-center justify-between gap-4 rounded-3xl bg-brand-50 px-6 py-6 text-sm text-brand-900">
+                            <div>
+                                <p className="text-xs font-semibold uppercase tracking-[0.35em] text-brand-600">Kolaborasi Berkelanjutan</p>
+                                <p className="mt-2 max-w-2xl text-sm text-brand-900">
+                                    Bagikan agenda dan kebutuhan Anda lebih awal agar kami dapat menyiapkan sumber daya terbaik, mulai dari fasilitator, penerjemah bahasa isyarat, hingga dokumentasi kegiatan.
+                                </p>
+                            </div>
+                            <Link
+                                href="/agenda"
+                                className="inline-flex items-center gap-2 rounded-full bg-brand-600 px-5 py-2 text-sm font-semibold text-white transition hover:bg-brand-700"
+                            >
+                                Lihat Agenda Terkini ↗
+                            </Link>
+                        </div>
                     </div>
                 </div>
             </section>

--- a/resources/js/pages/public/Home.tsx
+++ b/resources/js/pages/public/Home.tsx
@@ -1,8 +1,9 @@
-import { Head } from '@inertiajs/react';
+import { Head, Link } from '@inertiajs/react';
 import AppShell from '@/layouts/AppShell';
 import ProgramGrid from '@/components/vocational/ProgramGrid';
 import AlbumPreview from '@/components/home/AlbumPreview';
 import EventList from '@/components/home/EventList';
+import PostList from '@/components/home/PostList';
 import type { AlbumSummary, EventSummary, PostSummary } from '@/features/content/types';
 import type { VocationalProgram } from '@/features/vocational/types';
 
@@ -22,16 +23,44 @@ interface HomeProps {
     albums: AlbumSummary[];
 }
 
-const placeholderImage = 'https://placehold.co/950x400?text=950+x+400';
+const placeholderImage = 'https://placehold.co/1600x900?text=Profil+Sekolah+Inklusif';
 
 export default function Home({ settings, profile, programs, posts, events, albums }: HomeProps) {
     const siteName = settings?.site_name ?? 'SMK Negeri 10 Kuningan';
-    const tagline = settings?.tagline ?? "Where Tomorrow's Leaders Come Together";
+    const tagline = settings?.tagline ?? 'Mewujudkan pendidikan vokasional yang inklusif dan berdaya saing.';
 
-    const featuredPost = posts[0];
-    const otherPosts = posts.slice(1, 6);
-    const quote =
-        'Pendidikan merupakan tiket untuk masa depan. Hari esok untuk orang-orang yang telah mempersiapkan dirinya hari ini.';
+    const featuredPost = posts[0] ?? null;
+    const highlightedPrograms = programs.slice(0, 4);
+    const latestPosts = posts.slice(0, 6);
+    const spotlightAlbums = albums.slice(0, 3);
+    const highlightedEvents = events.slice(0, 4);
+
+    const upcomingEvent = events.find((event) => new Date(event.start_at) >= new Date()) ?? events[0] ?? null;
+
+    const stats = [
+        { label: 'Program Vokasional', value: programs.length },
+        { label: 'Agenda Aktif', value: events.length },
+        { label: 'Publikasi', value: posts.length },
+        { label: 'Album Galeri', value: albums.length },
+    ];
+
+    const commitments = [
+        {
+            title: 'Pembelajaran Adaptif',
+            description:
+                'Rencana pembelajaran yang fleksibel dan pendampingan sesuai kebutuhan peserta didik berkebutuhan khusus.',
+        },
+        {
+            title: 'Kolaborasi Industri',
+            description: 'Kemitraan dengan dunia usaha dan dunia industri untuk memberikan pengalaman kerja nyata.',
+        },
+        {
+            title: 'Lingkungan Inklusif',
+            description: 'Fasilitas aksesibel, komunitas suportif, dan budaya sekolah yang menjunjung keberagaman.',
+        },
+    ];
+
+    const heroImage = featuredPost?.cover_url ?? placeholderImage;
 
     return (
         <AppShell siteName={siteName} tagline={tagline}>
@@ -39,239 +68,268 @@ export default function Home({ settings, profile, programs, posts, events, album
                 <meta name="description" content={tagline} />
             </Head>
 
-            <section className="border-b border-slate-200 bg-gradient-to-br from-slate-50 to-white">
-                <div className="mx-auto grid w-full max-w-6xl gap-6 px-4 py-8 lg:grid-cols-[2.2fr_1fr]">
-                    <div className="overflow-hidden rounded-3xl border border-slate-200 bg-slate-100 shadow-xl animate-in fade-in duration-700">
-                        <div
-                            className="relative aspect-[19/8] w-full bg-slate-200"
-                            style={
-                                featuredPost?.cover_url
-                                    ? { backgroundImage: `url(${featuredPost.cover_url})`, backgroundSize: 'cover', backgroundPosition: 'center' }
-                                    : { backgroundImage: `url(${placeholderImage})`, backgroundSize: 'cover' }
-                            }
-                        >
-                            <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-transparent to-transparent" />
-                        </div>
-                        <div className="space-y-3 bg-gradient-to-r from-[#1b57d6] to-[#0f3bb2] p-6 text-white">
-                            <p className="text-[13px] uppercase tracking-[0.3em] text-white/70">Sorotan Utama</p>
-                            <h2 className="text-2xl font-semibold leading-tight">
-                                {featuredPost?.title ?? 'Selamat datang di portal resmi sekolah'}
-                            </h2>
-                            <p className="text-sm text-white/80">
-                                {featuredPost?.excerpt ??
-                                    'Temukan informasi terbaru seputar kegiatan, layanan, dan prestasi sekolah kami.'}
-                            </p>
-                            {featuredPost ? (
-                                <a
-                                    href={`/berita/${featuredPost.slug}`}
-                                    className="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.3em] text-amber-300 hover:text-amber-200 transition-colors"
-                                >
-                                    Baca selengkapnya ?
-                                </a>
-                            ) : null}
-                        </div>
-                    </div>
-                    <div className="flex flex-col gap-4 rounded-3xl border border-slate-200 bg-white p-5 shadow-sm">
-                        <h3 className="text-sm font-semibold uppercase tracking-[0.3em] text-slate-600">Agenda Terdekat</h3>
-                        {events.length ? (
-                            <ul className="space-y-3 text-sm text-slate-600">
-                                {events.slice(0, 5).map((event) => (
-                                    <li key={event.slug} className="rounded-md border border-slate-200 p-3">
-                                        <p className="text-xs uppercase tracking-[0.3em] text-[#1b57d6]">
-                                            {new Date(event.start_at ?? '').toLocaleDateString('id-ID', {
-                                                day: '2-digit',
-                                                month: 'long',
-                                                year: 'numeric',
-                                            })}
-                                        </p>
-                                        <a
-                                            href={`/agenda/${event.slug}`}
-                                            className="mt-1 block text-sm font-semibold text-slate-900"
-                                        >
-                                            {event.title}
-                                        </a>
-                                        {event.location ? (
-                                            <p className="text-xs text-slate-500">{event.location}</p>
-                                        ) : null}
-                                    </li>
-                                ))}
-                            </ul>
-                        ) : (
-                            <p className="text-sm text-slate-500">Belum ada agenda terbaru.</p>
-                        )}
-                    </div>
-                </div>
-            </section>
-
-            <section className="border-y border-[#1b57d6] bg-[#1b57d6]">
-                <div className="mx-auto flex w-full max-w-6xl items-center justify-between gap-4 px-4 py-3">
-                    <span className="rounded-full bg-amber-400 px-4 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-[#0b2b7a]">
-                        Kutipan
-                    </span>
-                    <p className="flex-1 text-center text-sm font-medium text-white">{quote} � Anonim</p>
-                </div>
-            </section>
-
-            <section className="bg-white">
-                <div className="mx-auto grid w-full max-w-6xl gap-8 px-4 py-10 lg:grid-cols-[2fr_1fr]">
-                    <div>
-                        <header className="border-b-4 border-[#1b57d6] pb-3">
-                            <h2 className="text-xl font-semibold uppercase tracking-[0.2em] text-[#1b57d6]">Tulisan Terbaru</h2>
-                        </header>
-                        <div className="mt-6 space-y-4">
-                            {otherPosts.map((post) => (
-                                <article
-                                    key={post.slug}
-                                    className="grid gap-4 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm md:grid-cols-[200px_1fr]"
-                                >
-                                    <div className="relative h-40 rounded-xl bg-slate-200">
-                                        {post.cover_url ? (
-                                            <img
-                                                src={post.cover_url}
-                                                alt={post.title}
-                                                className="h-full w-full rounded-xl object-cover"
-                                            />
-                                        ) : (
-                                            <div className="flex h-full w-full items-center justify-center text-sm text-slate-500">
-                                                400 x 250
-                                            </div>
-                                        )}
-                                    </div>
-                                    <div className="space-y-2">
-                                        <h3 className="text-lg font-semibold text-slate-900">
-                                            <a href={`/berita/${post.slug}`} className="hover:text-[#1b57d6]">
-                                                {post.title}
-                                            </a>
-                                        </h3>
-                                        <p className="text-sm text-slate-600">{post.excerpt}</p>
-                                        <div className="flex items-center justify-between text-[13px] text-slate-500">
-                                            <span>
-                                                {new Date(post.published_at ?? post.created_at ?? '').toLocaleDateString('id-ID', {
-                                                    day: '2-digit',
-                                                    month: 'long',
-                                                    year: 'numeric',
-                                                })}
-                                            </span>
-                                            <a
-                                                href={`/berita/${post.slug}`}
-                                                className="inline-flex items-center gap-1 rounded-full bg-amber-400 px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-[#0b2b7a]"
-                                            >
-                                                Baca
-                                            </a>
-                                        </div>
-                                    </div>
-                                </article>
-                            ))}
-                        </div>
-                    </div>
-                    <aside className="space-y-6">
-                        <div className="rounded-3xl border border-slate-200 bg-white p-5 shadow-sm">
-                            <div className="flex items-center gap-4">
-                                <div className="h-24 w-24 rounded-full bg-slate-200" />
-                                <div>
-                                    <p className="text-xs uppercase tracking-[0.3em] text-[#1b57d6]">Kepala Sekolah</p>
-                                    <h3 className="text-lg font-semibold text-slate-900">Anton Sofyan</h3>
-                                    <p className="text-xs text-slate-500">Sambutan singkat kepala sekolah</p>
-                                </div>
+            <main className="bg-slate-50">
+                <section className="relative isolate overflow-hidden bg-slate-900 text-white">
+                    <div
+                        aria-hidden
+                        className="absolute inset-0 bg-cover bg-center opacity-50"
+                        style={{ backgroundImage: `url(${heroImage})` }}
+                    />
+                    <div className="absolute inset-0 bg-gradient-to-br from-slate-900/80 via-slate-900/60 to-slate-900/80" />
+                    <div className="relative mx-auto grid w-full max-w-6xl gap-10 px-4 py-20 lg:grid-cols-[1.2fr_1fr]">
+                        <div className="space-y-6">
+                            <span className="inline-flex items-center rounded-full bg-emerald-400/20 px-4 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-emerald-200">
+                                Portal Publik
+                            </span>
+                            <div className="space-y-4">
+                                <h1 className="text-3xl font-semibold leading-tight text-white sm:text-4xl">
+                                    {siteName}: Ruang Berkembang untuk Semua
+                                </h1>
+                                <p className="max-w-2xl text-base text-slate-100 sm:text-lg">
+                                    {profile.excerpt ??
+                                        'Kami menghadirkan pembelajaran vokasional yang berpihak pada keberagaman dan memastikan setiap peserta didik mendapatkan dukungan optimal untuk meraih cita-cita.'}
+                                </p>
                             </div>
-                            <p className="mt-3 text-sm leading-relaxed text-slate-600">
-                                {profile.excerpt ?? 'Selamat datang di portal resmi kami. Mari bersinergi untuk pendidikan inklusif dan unggul.'}
-                            </p>
-                            <a
-                                href="/profil"
-                                className="mt-3 inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.2em] text-[#1b57d6]"
-                            >
-                                Selengkapnya ?
-                            </a>
+                            <div className="flex flex-wrap gap-3">
+                                <Link
+                                    href="/profil"
+                                    className="inline-flex items-center gap-2 rounded-full bg-white px-5 py-2 text-sm font-semibold text-slate-900 transition hover:bg-amber-200 hover:text-slate-900"
+                                >
+                                    Jelajahi Profil ↗
+                                </Link>
+                                <Link
+                                    href="/kontak"
+                                    className="inline-flex items-center gap-2 rounded-full border border-white/70 px-5 py-2 text-sm font-semibold text-white transition hover:bg-white/10"
+                                >
+                                    Hubungi Kami
+                                </Link>
+                            </div>
+                            {featuredPost && (
+                                <div className="rounded-2xl bg-white/10 p-4 backdrop-blur">
+                                    <p className="text-xs uppercase tracking-[0.3em] text-emerald-200">Sorotan Terbaru</p>
+                                    <Link
+                                        href={`/berita/${featuredPost.slug}`}
+                                        className="mt-2 block text-lg font-semibold text-white hover:text-amber-300"
+                                    >
+                                        {featuredPost.title}
+                                    </Link>
+                                    {featuredPost.excerpt && (
+                                        <p className="mt-1 text-sm text-slate-100">{featuredPost.excerpt}</p>
+                                    )}
+                                </div>
+                            )}
                         </div>
-
-                        <div className="rounded-3xl border border-slate-200 bg-white p-5 shadow-sm">
-                            <h3 className="text-sm font-semibold uppercase tracking-[0.3em] text-slate-600">Tautan</h3>
-                            <ul className="mt-3 space-y-2 text-sm text-[#1b57d6]">
-                                <li>
-                                    <a href="/profil" className="hover:underline">
-                                        Profil Sekolah
-                                    </a>
-                                </li>
-                                <li>
-                                    <a href="/vokasional" className="hover:underline">
-                                        Direktori Program
-                                    </a>
-                                </li>
-                                <li>
-                                    <a href="/berita" className="hover:underline">
-                                        Informasi PPDB 2025
-                                    </a>
-                                </li>
-                            </ul>
-                        </div>
-
-                        <div className="rounded-3xl border border-slate-200 bg-white p-5 shadow-sm">
-                            <h3 className="text-sm font-semibold uppercase tracking-[0.3em] text-slate-600">Paling Dikomentari</h3>
-                            <ul className="mt-3 space-y-3 text-sm text-slate-600">
-                                {posts.slice(0, 3).map((post) => (
-                                    <li key={post.slug} className="border-b border-dashed border-slate-200 pb-2 last:border-0">
-                                        <a href={`/berita/${post.slug}`} className="font-semibold text-[#1b57d6]">
-                                            {post.title}
-                                        </a>
-                                        <p className="text-xs text-slate-500">
-                                            {new Date(post.published_at ?? post.created_at ?? '').toLocaleDateString('id-ID', {
+                        <aside className="flex flex-col justify-between gap-6 rounded-3xl border border-white/20 bg-white/10 p-6 backdrop-blur">
+                            <div>
+                                <p className="text-xs uppercase tracking-[0.3em] text-emerald-200">Agenda Berikutnya</p>
+                                {upcomingEvent ? (
+                                    <div className="mt-3 space-y-2">
+                                        <p className="text-sm font-medium text-amber-200">
+                                            {new Date(upcomingEvent.start_at ?? '').toLocaleDateString('id-ID', {
                                                 day: '2-digit',
                                                 month: 'long',
                                                 year: 'numeric',
                                             })}
                                         </p>
-                                    </li>
+                                        <Link
+                                            href={`/agenda/${upcomingEvent.slug}`}
+                                            className="block text-lg font-semibold text-white hover:text-amber-300"
+                                        >
+                                            {upcomingEvent.title}
+                                        </Link>
+                                        {upcomingEvent.location ? (
+                                            <p className="text-sm text-slate-100">{upcomingEvent.location}</p>
+                                        ) : null}
+                                    </div>
+                                ) : (
+                                    <p className="mt-2 text-sm text-slate-100">Belum ada agenda yang dijadwalkan.</p>
+                                )}
+                            </div>
+                            <div className="rounded-2xl bg-slate-900/70 p-4 shadow-lg">
+                                <p className="text-sm font-semibold text-white">
+                                    "Pendidikan adalah tiket menuju masa depan. Hari esok dimiliki oleh mereka yang menyiapkan dirinya hari ini."
+                                </p>
+                                <p className="mt-2 text-xs uppercase tracking-[0.3em] text-emerald-200">— Malcolm X</p>
+                            </div>
+                        </aside>
+                    </div>
+                </section>
+
+                <section className="border-t border-white/40 bg-slate-50">
+                    <div className="mx-auto grid w-full max-w-6xl gap-4 px-4 py-10 sm:grid-cols-2 lg:grid-cols-4">
+                        {stats.map((stat) => (
+                            <div key={stat.label} className="rounded-3xl border border-slate-200 bg-white p-6 text-center shadow-sm">
+                                <p className="text-3xl font-semibold text-brand-600">{stat.value.toString().padStart(2, '0')}</p>
+                                <p className="mt-2 text-sm font-medium uppercase tracking-[0.2em] text-slate-500">{stat.label}</p>
+                            </div>
+                        ))}
+                    </div>
+                </section>
+
+                <section className="bg-white">
+                    <div className="mx-auto grid w-full max-w-6xl gap-10 px-4 py-12 lg:grid-cols-[1.4fr_1fr]">
+                        <div className="space-y-6">
+                            <header className="space-y-3">
+                                <p className="text-xs font-semibold uppercase tracking-[0.3em] text-brand-600">Komitmen Kami</p>
+                                <h2 className="text-2xl font-semibold text-slate-900">
+                                    Membuka akses pendidikan vokasional yang ramah semua peserta didik
+                                </h2>
+                            </header>
+                            <div className="grid gap-4 md:grid-cols-2">
+                                {commitments.map((commitment) => (
+                                    <div
+                                        key={commitment.title}
+                                        className="rounded-3xl border border-slate-200 bg-slate-50/60 p-5 shadow-sm"
+                                    >
+                                        <h3 className="text-lg font-semibold text-slate-900">{commitment.title}</h3>
+                                        <p className="mt-2 text-sm text-slate-600">{commitment.description}</p>
+                                    </div>
                                 ))}
-                            </ul>
+                            </div>
                         </div>
-
-                        <div className="rounded-3xl border border-slate-200 bg-white p-5 shadow-sm">
-                            <h3 className="text-sm font-semibold uppercase tracking-[0.3em] text-slate-600">Berlangganan</h3>
-                            <p className="mt-2 text-xs text-slate-500">Dapatkan informasi terbaru langsung ke email Anda.</p>
-                            <form className="mt-3 space-y-3 text-xs">
-                                <input
-                                    type="email"
-                                    placeholder="Alamat Email..."
-                                    className="w-full rounded-md border border-slate-200 px-3 py-2 text-slate-600 focus:border-[#1b57d6] focus:outline-none"
-                                />
-                                <button className="w-full rounded-md bg-[#1b57d6] py-2 font-semibold uppercase tracking-[0.2em] text-white transition hover:bg-[#0f3bb2]">
-                                    Daftar
-                                </button>
-                            </form>
-                        </div>
-                    </aside>
-                </div>
-            </section>
-
-            <section className="border-t border-slate-200 bg-slate-50">
-                <div className="mx-auto grid w-full max-w-6xl gap-8 px-4 py-10 lg:grid-cols-3">
-                    <div className="lg:col-span-2">
-                        <h3 className="text-lg font-semibold uppercase tracking-[0.2em] text-[#1b57d6]">Program Vokasional</h3>
-                        <p className="mt-2 text-sm text-slate-600">
-                            Program unggulan dengan pendampingan aksesibel dan kurikulum adaptif.
-                        </p>
-                        <div className="mt-4 rounded-3xl border border-slate-200 bg-white p-4 shadow-sm">
-                            <ProgramGrid items={programs} />
+                        <div className="rounded-3xl border border-slate-200 bg-slate-50/80 p-6 shadow-sm">
+                            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-brand-600">
+                                Sambutan Kepala Sekolah
+                            </p>
+                            <h3 className="mt-3 text-xl font-semibold text-slate-900">Selamat Datang</h3>
+                            <p className="mt-3 text-sm leading-relaxed text-slate-600">
+                                {profile.excerpt ??
+                                    'Terima kasih telah mengunjungi portal resmi kami. Mari berkolaborasi dalam menciptakan lingkungan belajar yang aman, ramah, dan penuh kesempatan.'}
+                            </p>
+                            <Link
+                                href="/profil"
+                                className="mt-6 inline-flex items-center gap-2 text-sm font-semibold text-brand-600 hover:text-brand-700"
+                            >
+                                Baca profil lengkap ↗
+                            </Link>
                         </div>
                     </div>
-                    <div>
-                        <h3 className="text-lg font-semibold uppercase tracking-[0.2em] text-[#1b57d6]">Agenda Terbaru</h3>
-                        <div className="mt-4 rounded-3xl border border-slate-200 bg-white p-4 shadow-sm">
-                            <EventList items={events} />
+                </section>
+
+                <section className="border-t border-slate-200 bg-slate-50">
+                    <div className="mx-auto w-full max-w-6xl px-4 py-12">
+                        <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+                            <div>
+                                <p className="text-xs font-semibold uppercase tracking-[0.3em] text-brand-600">Program Vokasional</p>
+                                <h2 className="text-2xl font-semibold text-slate-900">Kurikulum adaptif berbasis industri</h2>
+                                <p className="mt-2 max-w-xl text-sm text-slate-600">
+                                    Pilihan program yang dirancang bersama mitra industri serta menyediakan dukungan personal untuk peserta didik berkebutuhan khusus.
+                                </p>
+                            </div>
+                            <Link
+                                href="/vokasional"
+                                className="inline-flex items-center gap-2 text-sm font-semibold text-brand-600 hover:text-brand-700"
+                            >
+                                Lihat semua program ↗
+                            </Link>
+                        </div>
+                        <div className="mt-6 rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+                            <ProgramGrid items={highlightedPrograms} />
                         </div>
                     </div>
-                </div>
-            </section>
+                </section>
 
-            <section className="border-t border-slate-200 bg-white">
-                <div className="mx-auto w-full max-w-6xl px-4 py-10">
-                    <h3 className="text-lg font-semibold uppercase tracking-[0.2em] text-[#1b57d6]">Galeri Terbaru</h3>
-                    <div className="mt-4 rounded-3xl border border-slate-200 bg-white p-4 shadow-sm">
-                        <AlbumPreview items={albums} />
+                <section className="border-t border-slate-200 bg-white">
+                    <div className="mx-auto grid w-full max-w-6xl gap-10 px-4 py-12 lg:grid-cols-[1.4fr_1fr]">
+                        <div>
+                            <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+                                <div>
+                                    <p className="text-xs font-semibold uppercase tracking-[0.3em] text-brand-600">Berita Terbaru</p>
+                                    <h2 className="text-2xl font-semibold text-slate-900">Cerita dari komunitas sekolah</h2>
+                                </div>
+                                <Link
+                                    href="/berita"
+                                    className="inline-flex items-center gap-2 text-sm font-semibold text-brand-600 hover:text-brand-700"
+                                >
+                                    Arsip berita ↗
+                                </Link>
+                            </div>
+                            <div className="mt-6">
+                                <PostList items={latestPosts} />
+                            </div>
+                        </div>
+                        <aside className="space-y-6">
+                            <div className="rounded-3xl border border-slate-200 bg-slate-50/70 p-6 shadow-sm">
+                                <p className="text-xs font-semibold uppercase tracking-[0.3em] text-brand-600">Agenda Sekolah</p>
+                                <p className="mt-2 text-sm text-slate-600">
+                                    Ikuti perkembangan kegiatan pelatihan, workshop, dan seleksi peserta didik.
+                                </p>
+                                <div className="mt-5">
+                                    <EventList items={highlightedEvents} />
+                                </div>
+                                <Link
+                                    href="/agenda"
+                                    className="mt-4 inline-flex items-center gap-2 text-sm font-semibold text-brand-600 hover:text-brand-700"
+                                >
+                                    Agenda lengkap ↗
+                                </Link>
+                            </div>
+                            <div className="rounded-3xl border border-blue-200 bg-blue-50 p-6 text-slate-900 shadow-sm">
+                                <p className="text-xs font-semibold uppercase tracking-[0.3em] text-brand-600">Butuh Informasi Tambahan?</p>
+                                <p className="mt-2 text-sm text-slate-700">
+                                    Tim layanan publik siap membantu orang tua, mitra industri, dan masyarakat yang ingin berkolaborasi.
+                                </p>
+                                <Link
+                                    href="/kontak"
+                                    className="mt-4 inline-flex items-center gap-2 text-sm font-semibold text-brand-700 hover:text-brand-600"
+                                >
+                                    Hubungi layanan publik ↗
+                                </Link>
+                            </div>
+                        </aside>
                     </div>
-                </div>
-            </section>
+                </section>
+
+                <section className="border-t border-slate-200 bg-slate-50">
+                    <div className="mx-auto w-full max-w-6xl px-4 py-12">
+                        <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+                            <div>
+                                <p className="text-xs font-semibold uppercase tracking-[0.3em] text-brand-600">Galeri Terbaru</p>
+                                <h2 className="text-2xl font-semibold text-slate-900">Kilasan aktivitas peserta didik</h2>
+                                <p className="mt-2 max-w-xl text-sm text-slate-600">
+                                    Dokumentasi kegiatan praktik kerja, karya kreatif, dan momen kebersamaan di lingkungan sekolah.
+                                </p>
+                            </div>
+                            <Link
+                                href="/galeri"
+                                className="inline-flex items-center gap-2 text-sm font-semibold text-brand-600 hover:text-brand-700"
+                            >
+                                Semua album ↗
+                            </Link>
+                        </div>
+                        <div className="mt-6 rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+                            <AlbumPreview items={spotlightAlbums} />
+                        </div>
+                    </div>
+                </section>
+
+                <section className="border-t border-slate-200 bg-brand-600">
+                    <div className="mx-auto w-full max-w-6xl px-4 py-12 text-white">
+                        <div className="grid gap-6 lg:grid-cols-[2fr_1fr] lg:items-center">
+                            <div className="space-y-4">
+                                <h2 className="text-2xl font-semibold">Siap berkolaborasi dengan sekolah inklusif?</h2>
+                                <p className="max-w-2xl text-sm text-white/80">
+                                    Kami membuka ruang kolaborasi dengan lembaga, perusahaan, dan komunitas untuk menciptakan akses karier yang lebih luas bagi peserta didik vokasional. Mari wujudkan lingkungan belajar yang adil dan berkesinambungan.
+                                </p>
+                            </div>
+                            <div className="flex flex-col gap-3 sm:flex-row sm:justify-end">
+                                <Link
+                                    href="/kontak"
+                                    className="inline-flex items-center justify-center gap-2 rounded-full bg-white px-6 py-3 text-sm font-semibold text-brand-700 transition hover:bg-amber-200"
+                                >
+                                    Jadwalkan Kunjungan ↗
+                                </Link>
+                                <Link
+                                    href="/berita"
+                                    className="inline-flex items-center justify-center gap-2 rounded-full border border-white/80 px-6 py-3 text-sm font-semibold text-white transition hover:bg-white/10"
+                                >
+                                    Lihat cerita terbaru
+                                </Link>
+                            </div>
+                        </div>
+                    </div>
+                </section>
+            </main>
         </AppShell>
     );
 }

--- a/resources/js/pages/public/Profile.tsx
+++ b/resources/js/pages/public/Profile.tsx
@@ -1,4 +1,5 @@
-import { Head, usePage } from '@inertiajs/react';
+import { Head, Link, usePage } from '@inertiajs/react';
+import { useMemo } from 'react';
 import AppShell from '@/layouts/AppShell';
 import Breadcrumbs from '@/components/ui/Breadcrumbs';
 import type { Crumb } from '@/components/ui/Breadcrumbs';
@@ -7,6 +8,8 @@ type PageData = {
     title?: string;
     content?: string | null;
     slug?: string;
+    excerpt?: string | null;
+    meta_description?: string | null;
 };
 
 type PageProps = {
@@ -15,28 +18,190 @@ type PageProps = {
     };
 };
 
+type Heading = {
+    level: number;
+    text: string;
+    slug: string;
+};
+
+const stripHtml = (value: string) => value.replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim();
+
+const slugify = (value: string) =>
+    value
+        .toLowerCase()
+        .normalize('NFD')
+        .replace(/[^\w\s-]/g, '')
+        .trim()
+        .replace(/[-\s]+/g, '-');
+
+const enhanceContent = (rawHtml: string) => {
+    const headings: Heading[] = [];
+    const headingPattern = /<h([2-4])([^>]*)>([\s\S]*?)<\/h\1>/gi;
+
+    const htmlWithAnchors = rawHtml.replace(headingPattern, (_match, level, rawAttrs, innerHtml) => {
+        const textContent = stripHtml(innerHtml);
+        const fallbackSlug = slugify(textContent || `bagian-${headings.length + 1}`);
+        const idMatch = rawAttrs.match(/id="([^"]+)"/i);
+        const existingId = idMatch?.[1];
+
+        let slug = existingId ?? fallbackSlug;
+        let suffix = 2;
+        while (headings.some((heading) => heading.slug === slug)) {
+            slug = `${fallbackSlug}-${suffix}`;
+            suffix += 1;
+        }
+
+        headings.push({ level: Number(level), text: textContent, slug });
+
+        const hasId = Boolean(existingId);
+        const attrs = hasId ? rawAttrs : `${rawAttrs} id="${slug}"`;
+
+        return `<h${level}${attrs}>${innerHtml}</h${level}>`;
+    });
+
+    return { html: htmlWithAnchors, headings };
+};
+
 export default function Profile({ page }: { page: PageData | null }) {
     const { props } = usePage<PageProps>();
     const siteName = props?.settings?.site_name ?? 'SMK Negeri 10 Kuningan';
     const title = page?.title ?? 'Profil Sekolah';
     const content = page?.content ?? '<p>Konten profil belum tersedia.</p>';
 
+    const { html: enhancedContent, headings } = useMemo(() => enhanceContent(content), [content]);
+
+    const introText = useMemo(() => {
+        const source = page?.excerpt ?? stripHtml(content);
+        const sentences = source.split(/(?<=[.!?])\s+/).filter(Boolean);
+        const preview = sentences.slice(0, 2).join(' ');
+        return preview || 'Membangun lingkungan belajar vokasional yang inklusif, adaptif, dan kolaboratif untuk setiap peserta didik.';
+    }, [content, page?.excerpt]);
+
+    const description = page?.meta_description ?? introText;
+
+    const valueHighlights = [
+        {
+            title: 'Inklusif dan Adaptif',
+            description:
+                'Kami memastikan setiap peserta didik mendapatkan akses terhadap kurikulum yang relevan dengan dukungan yang sesuai kebutuhan.',
+        },
+        {
+            title: 'Kolaborasi Industri',
+            description:
+                'Program kemitraan dengan dunia usaha dan dunia industri dirancang untuk menghadirkan pengalaman belajar kontekstual.',
+        },
+        {
+            title: 'Budaya Sekolah Positif',
+            description:
+                'Lingkungan sekolah dibangun di atas rasa saling menghargai, keselamatan, dan pendampingan berkelanjutan.',
+        },
+    ];
+
+    const servicePillars = [
+        {
+            label: 'Layanan Bimbingan Individual',
+            detail: 'Pendampingan personal bagi peserta didik berkebutuhan khusus untuk merancang strategi belajar yang efektif.',
+        },
+        {
+            label: 'Penguatan Kompetensi',
+            detail: 'Pelatihan vokasional berbasis proyek dan praktik industri untuk membangun keterampilan siap kerja.',
+        },
+        {
+            label: 'Komunitas Orang Tua',
+            detail: 'Forum komunikasi intensif antara sekolah dan keluarga demi terciptanya kolaborasi pendidikan yang harmonis.',
+        },
+    ];
+
     const breadcrumbs: Crumb[] = [{ label: 'Profil', href: '/profil' }];
 
     return (
         <AppShell siteName={siteName}>
-            <Head title={`${title} - ${siteName}`} />
+            <Head title={`${title} - ${siteName}`}>
+                <meta name="description" content={description} />
+            </Head>
 
-            <section className="bg-white">
-                <div className="mx-auto w-full max-w-6xl px-4 py-10">
-                    <Breadcrumbs items={breadcrumbs} />
-                    <header className="mt-4 border-b-4 border-[#1b57d6] pb-3">
-                        <h1 className="text-xl font-semibold uppercase tracking-[0.2em] text-[#1b57d6]">{title}</h1>
-                    </header>
+            <section className="bg-gradient-to-b from-slate-900 via-slate-900 to-slate-800 text-white">
+                <div className="mx-auto w-full max-w-6xl px-4 pb-16 pt-14 lg:pt-20">
+                    <Breadcrumbs items={breadcrumbs} variant="dark" className="text-slate-200" />
+                    <div className="mt-10 grid gap-12 lg:grid-cols-[1.4fr_1fr] lg:items-start">
+                        <header className="space-y-6">
+                            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-emerald-200">Profil Sekolah</p>
+                            <h1 className="text-3xl font-semibold leading-tight sm:text-4xl">{title}</h1>
+                            <p className="max-w-2xl text-base text-slate-100 sm:text-lg">{introText}</p>
+                            <div className="flex flex-wrap gap-3">
+                                <Link
+                                    href="/visi-misi"
+                                    className="inline-flex items-center gap-2 rounded-full bg-white px-5 py-2 text-sm font-semibold text-slate-900 transition hover:bg-amber-200"
+                                >
+                                    Lihat Visi &amp; Misi ↗
+                                </Link>
+                                <Link
+                                    href="/kontak"
+                                    className="inline-flex items-center gap-2 rounded-full border border-white/70 px-5 py-2 text-sm font-semibold text-white transition hover:bg-white/10"
+                                >
+                                    Terhubung dengan Kami
+                                </Link>
+                            </div>
+                        </header>
+                        <aside className="space-y-4 rounded-3xl border border-white/20 bg-white/10 p-6 backdrop-blur">
+                            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-emerald-200">Sorotan Nilai</p>
+                            <ul className="space-y-4 text-sm text-slate-100">
+                                {valueHighlights.map((highlight) => (
+                                    <li key={highlight.title} className="space-y-1">
+                                        <p className="font-semibold text-white">{highlight.title}</p>
+                                        <p>{highlight.description}</p>
+                                    </li>
+                                ))}
+                            </ul>
+                        </aside>
+                    </div>
+                </div>
+            </section>
+
+            <section className="bg-slate-50">
+                <div className="mx-auto grid w-full max-w-6xl gap-8 px-4 pb-16 pt-12 lg:grid-cols-[1fr_280px]">
                     <article
-                        className="prose mt-6 max-w-none rounded-3xl border border-slate-200 bg-white p-6 text-slate-700 shadow-sm"
-                        dangerouslySetInnerHTML={{ __html: content }}
+                        className="prose prose-slate max-w-none rounded-3xl border border-slate-200 bg-white p-8 shadow-sm"
+                        dangerouslySetInnerHTML={{ __html: enhancedContent }}
                     />
+                    <aside className="space-y-6 rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+                        <div>
+                            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-brand-600">Navigasi Cepat</p>
+                            {headings.length > 0 ? (
+                                <ul className="mt-4 space-y-3 text-sm text-slate-600">
+                                    {headings.map((heading) => {
+                                        const indentClass =
+                                            heading.level === 2 ? 'pl-0' : heading.level === 3 ? 'pl-4' : 'pl-8';
+
+                                        return (
+                                            <li key={heading.slug} className={indentClass}>
+                                                <a
+                                                    href={`#${heading.slug}`}
+                                                    className="inline-flex items-center gap-2 text-slate-700 transition hover:text-brand-600"
+                                                >
+                                                    <span className="h-1.5 w-1.5 rounded-full bg-brand-500" aria-hidden />
+                                                    {heading.text}
+                                                </a>
+                                            </li>
+                                        );
+                                    })}
+                                </ul>
+                            ) : (
+                                <p className="mt-4 text-sm text-slate-500">Bagian profil akan diperbarui secara berkala.</p>
+                            )}
+                        </div>
+                        <div className="space-y-3 rounded-2xl bg-slate-50 p-4">
+                            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-brand-600">Layanan Utama</p>
+                            <ul className="space-y-3 text-sm text-slate-600">
+                                {servicePillars.map((pillar) => (
+                                    <li key={pillar.label} className="space-y-1">
+                                        <p className="font-semibold text-slate-900">{pillar.label}</p>
+                                        <p>{pillar.detail}</p>
+                                    </li>
+                                ))}
+                            </ul>
+                        </div>
+                    </aside>
                 </div>
             </section>
         </AppShell>

--- a/resources/js/pages/public/VisionMission.tsx
+++ b/resources/js/pages/public/VisionMission.tsx
@@ -1,4 +1,5 @@
-import { Head, usePage } from '@inertiajs/react';
+import { Head, Link, usePage } from '@inertiajs/react';
+import { useMemo } from 'react';
 import AppShell from '@/layouts/AppShell';
 import Breadcrumbs from '@/components/ui/Breadcrumbs';
 
@@ -6,6 +7,8 @@ interface VisionMissionProps {
     page: {
         title?: string;
         content?: string | null;
+        excerpt?: string | null;
+        meta_description?: string | null;
     } | null;
     vision?: string | null;
     missions?: string[];
@@ -17,49 +20,186 @@ type PageProps = {
     };
 };
 
+const stripHtml = (value: string) => value.replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim();
+
+const removeSectionByHeading = (html: string, heading: string) => {
+    const pattern = new RegExp(`<h[23][^>]*>\\s*${heading}[\\s\\S]*?(?=<h[23][^>]*>|$)`, 'i');
+    return html.replace(pattern, '').trim();
+};
+
 export default function VisionMission({ page, vision, missions = [] }: VisionMissionProps) {
     const { props } = usePage<PageProps>();
     const siteName = props?.settings?.site_name ?? 'SMK Negeri 10 Kuningan';
     const title = page?.title ?? 'Visi & Misi';
 
+    const defaultVision =
+        'Menjadi pusat vokasional yang memerdekakan potensi setiap peserta didik melalui pembelajaran inklusif, kolaboratif, dan berdaya saing global.';
+    const displayedVision = vision?.trim() || defaultVision;
+
+    const defaultMissions = [
+        'Menyelenggarakan layanan pendidikan yang adaptif terhadap kebutuhan setiap peserta didik.',
+        'Membangun jejaring kolaborasi dengan dunia usaha, dunia industri, dan komunitas untuk memperkuat pengalaman belajar.',
+        'Menciptakan budaya sekolah yang aman, suportif, dan menumbuhkan kemandirian.',
+        'Mengintegrasikan teknologi serta pendekatan pembelajaran diferensiatif untuk mengoptimalkan potensi.',
+    ];
+
+    const missionItems = missions.length ? missions : defaultMissions;
+
+    const heroSummary = (() => {
+        const excerpt = page?.excerpt ?? '';
+        const summary = stripHtml(excerpt) ||
+            'Haluan visi dan misi kami berfokus pada pemberdayaan peserta didik berkebutuhan khusus agar siap berkiprah di masyarakat dan dunia kerja.';
+        return summary;
+    })();
+
+    const description = page?.meta_description?.trim() || heroSummary;
+
+    const additionalContent = useMemo(() => {
+        if (!page?.content) {
+            return null;
+        }
+
+        let cleaned = page.content;
+        cleaned = removeSectionByHeading(cleaned, 'Visi');
+        cleaned = removeSectionByHeading(cleaned, 'Misi');
+
+        const textPreview = stripHtml(cleaned);
+        if (!textPreview) {
+            return null;
+        }
+
+        return cleaned;
+    }, [page?.content]);
+
+    const focusAreas = [
+        {
+            title: 'Pembelajaran Personal',
+            description:
+                'Pendekatan diferensiatif, asesmen autentik, dan dukungan interdisipliner memastikan setiap peserta didik bergerak sesuai ritmenya.',
+        },
+        {
+            title: 'Sinergi Industri & Komunitas',
+            description:
+                'Kolaborasi intensif dengan mitra usaha, lembaga layanan, dan komunitas memfasilitasi praktik kerja serta penguatan soft skills.',
+        },
+        {
+            title: 'Budaya Sekolah Inklusif',
+            description:
+                'Lingkungan yang aman, menghargai keberagaman, dan mengedepankan kesejahteraan menjadi pondasi tumbuhnya karakter mandiri.',
+        },
+    ];
+
     return (
         <AppShell siteName={siteName}>
-            <Head title={`${title} - ${siteName}`} />
+            <Head title={`${title} - ${siteName}`}>
+                <meta name="description" content={description} />
+            </Head>
 
-            <section className="bg-white">
-                <div className="mx-auto w-full max-w-6xl px-4 py-10">
-                    <Breadcrumbs items={[{ label: 'Visi & Misi', href: '/visi-misi' }]} />
-                    <header className="mt-4 border-b-4 border-[#1b57d6] pb-3">
-                        <h1 className="text-xl font-semibold uppercase tracking-[0.2em] text-[#1b57d6]">{title}</h1>
-                        <p className="mt-2 text-sm text-slate-600">
-                            Menjadi pusat vokasional inklusif yang memberdayakan peserta didik dengan berbagai kebutuhan khusus.
-                        </p>
-                    </header>
-                    <div className="mt-6 grid gap-6 lg:grid-cols-2">
-                        <div className="rounded-3xl border border-[#1b57d6]/30 bg-[#1b57d6]/5 p-6 shadow-sm">
-                            <h2 className="text-lg font-semibold text-[#1b57d6]">Visi</h2>
-                            <p className="mt-3 leading-relaxed text-slate-700">{vision ?? 'Visi belum tersedia.'}</p>
-                        </div>
-                        <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
-                            <h2 className="text-lg font-semibold text-[#1b57d6]">Misi</h2>
-                            {missions.length ? (
-                                <ol className="mt-3 space-y-3 text-slate-700">
-                                    {missions.map((mission, index) => (
-                                        <li key={index} className="flex gap-3">
-                                            <span className="mt-1 inline-flex h-7 w-7 items-center justify-center rounded-full bg-[#1b57d6] text-xs font-semibold text-white">
-                                                {index + 1}
-                                            </span>
-                                            <span className="leading-relaxed">{mission}</span>
-                                        </li>
-                                    ))}
-                                </ol>
-                            ) : (
-                                <p className="mt-3 text-sm text-slate-500">Misi belum tersedia.</p>
-                            )}
-                        </div>
+            <section className="relative overflow-hidden bg-gradient-to-b from-slate-900 via-slate-900 to-slate-800 text-white">
+                <div className="pointer-events-none absolute inset-0 opacity-40">
+                    <div className="absolute -left-20 top-10 h-40 w-40 rounded-full bg-emerald-400/30 blur-3xl" />
+                    <div className="absolute -right-16 bottom-0 h-56 w-56 rounded-full bg-sky-500/20 blur-3xl" />
+                </div>
+                <div className="relative mx-auto w-full max-w-6xl px-4 pb-16 pt-14 lg:pt-20">
+                    <Breadcrumbs
+                        items={[{ label: 'Visi & Misi', href: '/visi-misi' }]}
+                        variant="dark"
+                        className="text-slate-200"
+                    />
+                    <div className="mt-10 grid gap-12 lg:grid-cols-[1.4fr_1fr] lg:items-start">
+                        <header className="space-y-6">
+                            <p className="text-xs font-semibold uppercase tracking-[0.35em] text-emerald-200">Arah Pendidikan</p>
+                            <h1 className="text-3xl font-semibold leading-tight sm:text-4xl">{title}</h1>
+                            <p className="max-w-2xl text-base text-slate-100 sm:text-lg">{heroSummary}</p>
+                            <div className="flex flex-wrap gap-3">
+                                <Link
+                                    href="/profil"
+                                    className="inline-flex items-center gap-2 rounded-full bg-white px-5 py-2 text-sm font-semibold text-slate-900 transition hover:bg-amber-200"
+                                >
+                                    Telusuri Profil Sekolah ↗
+                                </Link>
+                                <Link
+                                    href="/kontak"
+                                    className="inline-flex items-center gap-2 rounded-full border border-white/70 px-5 py-2 text-sm font-semibold text-white transition hover:bg-white/10"
+                                >
+                                    Kolaborasi dengan Kami
+                                </Link>
+                            </div>
+                        </header>
+                        <aside className="space-y-4 rounded-3xl border border-white/20 bg-white/10 p-6 backdrop-blur">
+                            <p className="text-xs font-semibold uppercase tracking-[0.35em] text-emerald-200">Pernyataan Visi</p>
+                            <p className="text-lg font-semibold text-white">{displayedVision}</p>
+                            <p className="text-sm text-slate-100/90">
+                                Visi menjadi kompas dalam setiap program pembelajaran, layanan bimbingan, dan kemitraan strategis yang sekolah
+                                hadirkan.
+                            </p>
+                        </aside>
                     </div>
                 </div>
             </section>
+
+            <section className="bg-white">
+                <div className="mx-auto w-full max-w-6xl px-4 py-16">
+                    <div className="grid gap-10 lg:grid-cols-[1fr_340px] lg:items-start">
+                        <div>
+                            <h2 className="text-2xl font-semibold text-slate-900">Misi Sekolah</h2>
+                            <p className="mt-3 max-w-2xl text-base text-slate-600">
+                                Misi berikut menjadi langkah nyata dalam mewujudkan visi sekolah melalui pembelajaran yang relevan dan dukungan yang
+                                menyeluruh bagi peserta didik.
+                            </p>
+                        </div>
+                        <div className="rounded-3xl border border-slate-200 bg-slate-50 p-6">
+                            <p className="text-xs font-semibold uppercase tracking-[0.35em] text-brand-600">Ikhtisar</p>
+                            <p className="mt-3 text-sm text-slate-600">
+                                {missions.length
+                                    ? 'Data misi diambil langsung dari dokumen visi & misi sekolah dan diperbarui oleh tim pengelola konten.'
+                                    : 'Daftar misi berikut merupakan gambaran umum arah kebijakan sekolah ketika konten resmi belum tersedia.'}
+                            </p>
+                        </div>
+                    </div>
+
+                    <div className="mt-10 grid gap-6 md:grid-cols-2">
+                        {missionItems.map((mission, index) => (
+                            <div
+                                key={`${index}-${mission.slice(0, 12)}`}
+                                className="flex gap-4 rounded-3xl border border-slate-200 bg-white p-6 shadow-sm"
+                            >
+                                <span className="inline-flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-brand-600 text-lg font-semibold text-white">
+                                    {index + 1}
+                                </span>
+                                <p className="text-base leading-relaxed text-slate-700">{mission}</p>
+                            </div>
+                        ))}
+                    </div>
+                </div>
+            </section>
+
+            <section className="bg-slate-50">
+                <div className="mx-auto w-full max-w-6xl px-4 py-16">
+                    <div className="grid gap-6 lg:grid-cols-3">
+                        {focusAreas.map((area) => (
+                            <div key={area.title} className="flex h-full flex-col justify-between rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+                                <div className="space-y-3">
+                                    <p className="text-xs font-semibold uppercase tracking-[0.35em] text-brand-600">Fokus Implementasi</p>
+                                    <h3 className="text-lg font-semibold text-slate-900">{area.title}</h3>
+                                    <p className="text-sm text-slate-600">{area.description}</p>
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+                </div>
+            </section>
+
+            {additionalContent && (
+                <section className="bg-white">
+                    <div className="mx-auto w-full max-w-6xl px-4 py-16">
+                        <article
+                            className="prose prose-slate max-w-none rounded-3xl border border-slate-200 bg-white p-8 shadow-sm"
+                            dangerouslySetInnerHTML={{ __html: additionalContent }}
+                        />
+                    </div>
+                </section>
+            )}
         </AppShell>
     );
 }

--- a/resources/js/pages/vocational/Index.tsx
+++ b/resources/js/pages/vocational/Index.tsx
@@ -1,8 +1,11 @@
-import { Head, usePage } from '@inertiajs/react';
+import { useMemo, useState } from 'react';
+import { Head, Link, usePage } from '@inertiajs/react';
+import { Layers, Search, Sparkles, UsersRound } from 'lucide-react';
 import AppShell from '@/layouts/AppShell';
 import Breadcrumbs from '@/components/ui/Breadcrumbs';
 import ProgramGrid from '@/components/vocational/ProgramGrid';
 import type { VocationalProgram } from '@/features/vocational/types';
+import type { MediaItem } from '@/features/vocational/types';
 
 interface VocationalIndexProps {
     items: VocationalProgram[];
@@ -11,38 +14,318 @@ interface VocationalIndexProps {
 type PageProps = {
     settings?: {
         site_name?: string;
+        tagline?: string;
     };
 };
+
+type ProgramWithMeta = VocationalProgram & {
+    media: MediaItem[];
+    focusTags: string[];
+};
+
+const heroPlaceholder = 'https://placehold.co/1600x900/1b57d6/ffffff?text=Program+Vokasional';
+
+function normaliseUrl(url: string) {
+    if (!url) {
+        return url;
+    }
+
+    return url.startsWith('http') ? url : `/storage/${url}`;
+}
 
 export default function VocationalIndex({ items }: VocationalIndexProps) {
     const { props } = usePage<PageProps>();
     const siteName = props?.settings?.site_name ?? 'SMK Negeri 10 Kuningan';
+    const tagline = props?.settings?.tagline ?? 'Where Tomorrow\'s Leaders Come Together';
 
-    // Map photos array to media array for each vocational program
-    const itemsWithMedia = items.map((item) => ({
-        ...item,
-        media: item.photos?.map((photo, index) => ({
-            id: index + 1, // Using index as id
-            type: 'image' as const,
-            url: photo.startsWith('http') ? photo : `/storage/${photo}`,
-            alt: item.title,
-        })) ?? [],
-    }));
+    const programs = useMemo<ProgramWithMeta[]>(() => {
+        return items.map((item) => {
+            const media: MediaItem[] =
+                item.media && item.media.length > 0
+                    ? item.media.map((mediaItem) => ({
+                          ...mediaItem,
+                          url: normaliseUrl(mediaItem.url),
+                      }))
+                    : (item.photos ?? []).map((photo, index) => ({
+                          id: index + 1,
+                          type: 'image' as const,
+                          url: normaliseUrl(photo),
+                          alt: item.title,
+                      }));
+
+            const focusTags = item.audience
+                ? item.audience
+                      .split(',')
+                      .map((value) => value.trim())
+                      .filter(Boolean)
+                : [];
+
+            return {
+                ...item,
+                media,
+                focusTags,
+            };
+        });
+    }, [items]);
+
+    const heroImage = programs.find((program) => program.media.length > 0)?.media[0]?.url ?? heroPlaceholder;
+
+    const [searchTerm, setSearchTerm] = useState('');
+    const [activeFocus, setActiveFocus] = useState<string>('all');
+
+    const focusOptions = useMemo(() => {
+        const counts = new Map<string, number>();
+
+        programs.forEach((program) => {
+            const tags = program.focusTags.length > 0 ? program.focusTags : ['Terbuka untuk Semua'];
+            tags.forEach((tag) => {
+                counts.set(tag, (counts.get(tag) ?? 0) + 1);
+            });
+        });
+
+        return Array.from(counts.entries())
+            .map(([value, count]) => ({ value, count }))
+            .sort((a, b) => a.value.localeCompare(b.value));
+    }, [programs]);
+
+    const filteredPrograms = useMemo(() => {
+        const query = searchTerm.trim().toLowerCase();
+
+        return programs.filter((program) => {
+            const matchesQuery =
+                query.length === 0 ||
+                [program.title, program.description, program.audience, program.schedule]
+                    .filter(Boolean)
+                    .some((field) => (field as string).toLowerCase().includes(query));
+
+            if (activeFocus === 'all') {
+                return matchesQuery;
+            }
+
+            const focusPool = program.focusTags.length > 0 ? program.focusTags : ['Terbuka untuk Semua'];
+            return matchesQuery && focusPool.includes(activeFocus);
+        });
+    }, [programs, searchTerm, activeFocus]);
+
+    const visiblePrograms = useMemo(() => filteredPrograms as VocationalProgram[], [filteredPrograms]);
+
+    const aggregated = useMemo(() => {
+        const facilitySet = new Set<string>();
+        const mentorSet = new Set<string>();
+        const outcomeSet = new Set<string>();
+
+        programs.forEach((program) => {
+            program.facilities?.forEach((facility) => facilitySet.add(facility));
+            program.mentors?.forEach((mentor) => mentorSet.add(mentor));
+            program.outcomes?.forEach((outcome) => outcomeSet.add(outcome));
+        });
+
+        return {
+            facilityCount: facilitySet.size,
+            mentorCount: mentorSet.size,
+            outcomeCount: outcomeSet.size,
+        };
+    }, [programs]);
 
     return (
-        <AppShell siteName={siteName}>
-            <Head title={`Program Vokasional - ${siteName}`} />
+        <AppShell siteName={siteName} tagline={tagline}>
+            <Head title={`Direktori Program Vokasional - ${siteName}`}>
+                <meta
+                    name="description"
+                    content={`Jelajahi program vokasional ${siteName} lengkap dengan fokus pembelajaran, fasilitas, serta mentor profesional.`}
+                />
+            </Head>
 
-            <section className="bg-white">
-                <div className="mx-auto w-full max-w-6xl px-4 py-10">
-                    <Breadcrumbs items={[{ label: 'Vokasional', href: '/vokasional' }]} />
-                    <header className="mt-4 border-b-4 border-[#1b57d6] pb-3">
-                        <h1 className="text-xl font-semibold uppercase tracking-[0.2em] text-[#1b57d6]">SMK Negeri 10 Kuningan</h1>
-                        <p className="mt-2 text-sm text-slate-600">Where Tomorrow's Leaders Come Together</p>
-                    </header>
-                    <div className="mt-6 rounded-3xl border border-slate-200 bg-white p-4 shadow-sm">
-                        <ProgramGrid items={itemsWithMedia} />
+            <section className="relative isolate overflow-hidden bg-slate-900 text-white">
+                <div
+                    aria-hidden
+                    className="absolute inset-0 bg-cover bg-center opacity-40"
+                    style={{ backgroundImage: `url(${heroImage})` }}
+                />
+                <div className="absolute inset-0 bg-gradient-to-br from-slate-900/85 via-slate-900/70 to-slate-900/90" />
+                <div className="relative mx-auto w-full max-w-6xl px-4 py-20">
+                    <Breadcrumbs
+                        items={[{ label: 'Direktori Program Vokasional', href: '/vokasional' }]}
+                        variant="dark"
+                    />
+
+                    <div className="mt-12 grid gap-12 lg:grid-cols-[1.5fr_1fr]">
+                        <div className="space-y-8">
+                            <span className="inline-flex items-center gap-2 rounded-full bg-emerald-400/15 px-4 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-emerald-200">
+                                <Sparkles className="h-4 w-4" aria-hidden />
+                                Program Unggulan
+                            </span>
+                            <div className="space-y-4">
+                                <h1 className="text-3xl font-semibold leading-tight text-white sm:text-4xl">
+                                    {siteName}: Direktori Program Vokasional Inklusif
+                                </h1>
+                                <p className="max-w-2xl text-base text-slate-100 sm:text-lg">
+                                    Temukan jalur vokasional yang dirancang adaptif untuk kebutuhan beragam peserta didik. Setiap program
+                                    menghadirkan kurikulum terapan, fasilitas aksesibel, dan pendampingan mentor profesional.
+                                </p>
+                            </div>
+                            <div className="flex flex-wrap gap-3">
+                                <Link
+                                    href="/profil"
+                                    className="inline-flex items-center gap-2 rounded-full bg-white px-5 py-2 text-sm font-semibold text-slate-900 transition hover:bg-amber-200"
+                                >
+                                    Pelajari Profil Sekolah ↗
+                                </Link>
+                                <Link
+                                    href="/hubungi-kami"
+                                    className="inline-flex items-center gap-2 rounded-full border border-white/70 px-5 py-2 text-sm font-semibold text-white transition hover:bg-white/10"
+                                >
+                                    Konsultasi Program
+                                </Link>
+                            </div>
+                        </div>
+
+                        <aside className="flex flex-col gap-4 rounded-3xl border border-white/20 bg-white/10 p-6 backdrop-blur">
+                            <div>
+                                <p className="text-xs uppercase tracking-[0.3em] text-emerald-200">Jumlah Program</p>
+                                <p className="mt-2 text-3xl font-semibold text-white">{programs.length.toString().padStart(2, '0')}</p>
+                                <p className="text-sm text-slate-100">Pilihan jalur keahlian yang aktif dibuka untuk peserta didik.</p>
+                            </div>
+                            <div>
+                                <p className="text-xs uppercase tracking-[0.3em] text-emerald-200">Fokus Pembelajaran</p>
+                                <p className="mt-2 text-lg font-semibold text-white">{focusOptions.length}</p>
+                                <p className="text-sm text-slate-100">Bidang minat berbeda dengan modul praktik adaptif.</p>
+                            </div>
+                            <div>
+                                <p className="text-xs uppercase tracking-[0.3em] text-emerald-200">Mentor Profesional</p>
+                                <p className="mt-2 text-lg font-semibold text-white">{aggregated.mentorCount}</p>
+                                <p className="text-sm text-slate-100">Jejaring pendamping industri dan guru kejuruan.</p>
+                            </div>
+                        </aside>
                     </div>
+                </div>
+            </section>
+
+            <section className="bg-slate-50 py-12">
+                <div className="mx-auto flex w-full max-w-6xl flex-col gap-10 px-4">
+                    <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+                        <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+                            <div className="max-w-xl space-y-3">
+                                <h2 className="text-2xl font-semibold text-slate-900">Jelajahi Program yang Tepat</h2>
+                                <p className="text-sm leading-relaxed text-slate-600">
+                                    Gunakan pencarian dan filter fokus untuk menemukan program vokasional sesuai minat dan kebutuhan pendampingan.
+                                </p>
+                            </div>
+                            <div className="relative w-full max-w-sm">
+                                <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" aria-hidden />
+                                <input
+                                    type="search"
+                                    value={searchTerm}
+                                    onChange={(event) => setSearchTerm(event.target.value)}
+                                    placeholder="Cari program, jadwal, atau sasaran..."
+                                    className="h-11 w-full rounded-full border border-slate-200 bg-slate-50 px-10 text-sm font-medium text-slate-700 placeholder:text-slate-400 focus:border-brand-500 focus:bg-white focus:outline-none focus:ring-2 focus:ring-brand-200"
+                                />
+                            </div>
+                        </div>
+                        {focusOptions.length > 0 ? (
+                            <div className="mt-6 flex flex-wrap gap-2">
+                                <button
+                                    type="button"
+                                    onClick={() => setActiveFocus('all')}
+                                    className="inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.2em] transition hover:border-brand-500 hover:text-brand-600"
+                                    data-active={activeFocus === 'all'}
+                                    aria-pressed={activeFocus === 'all'}
+                                >
+                                    <Layers className="h-4 w-4" aria-hidden />
+                                    Semua Fokus
+                                    <span className="rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-bold">{programs.length}</span>
+                                </button>
+                                {focusOptions.map((option) => (
+                                    <button
+                                        key={option.value}
+                                        type="button"
+                                        onClick={() => setActiveFocus(option.value)}
+                                        className="inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.2em] transition hover:border-brand-500 hover:text-brand-600 data-[active=true]:border-brand-500 data-[active=true]:bg-brand-50 data-[active=true]:text-brand-700"
+                                        data-active={activeFocus === option.value}
+                                        aria-pressed={activeFocus === option.value}
+                                    >
+                                        <UsersRound className="h-4 w-4" aria-hidden />
+                                        {option.value}
+                                        <span className="rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-bold">{option.count}</span>
+                                    </button>
+                                ))}
+                            </div>
+                        ) : null}
+                    </div>
+
+                    <div className="space-y-8">
+                        <header className="space-y-2">
+                            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-brand-600">Direktori Lengkap</p>
+                            <h3 className="text-xl font-semibold text-slate-900">
+                                {activeFocus === 'all' ? 'Seluruh program vokasional tersedia' : `Program dengan fokus ${activeFocus}`}
+                            </h3>
+                            {searchTerm ? (
+                                <p className="text-sm text-slate-500">
+                                    Menampilkan hasil untuk "{searchTerm}" — {visiblePrograms.length} program ditemukan.
+                                </p>
+                            ) : null}
+                        </header>
+
+                        <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+                            {visiblePrograms.length > 0 ? (
+                                <ProgramGrid items={visiblePrograms} />
+                            ) : (
+                                <div className="flex flex-col items-center gap-3 py-12 text-center">
+                                    <Sparkles className="h-10 w-10 text-brand-500" aria-hidden />
+                                    <p className="text-sm font-semibold text-slate-700">Belum ada program yang sesuai pencarian Anda.</p>
+                                    <p className="max-w-md text-sm text-slate-500">
+                                        Coba ubah kata kunci atau pilih fokus lain. Anda juga dapat menghubungi tim kami untuk rekomendasi program yang paling relevan.
+                                    </p>
+                                    <Link
+                                        href="/hubungi-kami"
+                                        className="inline-flex items-center gap-2 rounded-full bg-brand-600 px-5 py-2 text-sm font-semibold text-white transition hover:bg-brand-500"
+                                    >
+                                        Hubungi Tim Akademik ↗
+                                    </Link>
+                                </div>
+                            )}
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <section className="bg-white py-16">
+                <div className="mx-auto grid w-full max-w-6xl gap-8 px-4 lg:grid-cols-[1.2fr_1fr]">
+                    <div className="space-y-4">
+                        <p className="text-xs font-semibold uppercase tracking-[0.3em] text-brand-600">Mengapa Memilih Program Kami</p>
+                        <h3 className="text-2xl font-semibold text-slate-900">Ekosistem vokasional yang terhubung dengan dunia kerja</h3>
+                        <p className="text-sm leading-relaxed text-slate-600">
+                            Kolaborasi dengan industri dan komunitas memungkinkan peserta didik belajar melalui praktik langsung. Fasilitas yang adaptif,
+                            jejaring mentor lintas bidang, dan kurikulum berbasis proyek memastikan setiap program menjawab kebutuhan dunia kerja masa kini.
+                        </p>
+                        <div className="grid gap-4 sm:grid-cols-2">
+                            <div className="rounded-3xl border border-slate-200 bg-slate-50/80 p-5">
+                                <p className="text-xs font-semibold uppercase tracking-[0.3em] text-brand-600">Fasilitas Unggulan</p>
+                                <p className="mt-2 text-2xl font-semibold text-slate-900">{aggregated.facilityCount}</p>
+                                <p className="text-sm text-slate-600">Laboratorium, studio, dan ruang praktik yang siap digunakan untuk pembelajaran adaptif.</p>
+                            </div>
+                            <div className="rounded-3xl border border-slate-200 bg-slate-50/80 p-5">
+                                <p className="text-xs font-semibold uppercase tracking-[0.3em] text-brand-600">Hasil Pembelajaran</p>
+                                <p className="mt-2 text-2xl font-semibold text-slate-900">{aggregated.outcomeCount}</p>
+                                <p className="text-sm text-slate-600">Kompetensi spesifik yang dikurasi bersama mitra industri untuk kesiapan kerja.</p>
+                            </div>
+                        </div>
+                    </div>
+                    <aside className="flex flex-col justify-between gap-6 rounded-3xl border border-slate-200 bg-slate-50 p-6 shadow-sm">
+                        <div>
+                            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-brand-600">Butuh Bantuan?</p>
+                            <p className="mt-2 text-lg font-semibold text-slate-900">Tim layanan pendidikan siap membantu.</p>
+                            <p className="mt-2 text-sm text-slate-600">
+                                Konsultasikan kebutuhan pembelajaran khusus, rencana magang, atau penempatan dunia kerja untuk setiap peserta didik.
+                            </p>
+                        </div>
+                        <Link
+                            href="/hubungi-kami"
+                            className="inline-flex items-center justify-center gap-2 rounded-full bg-brand-600 px-5 py-2 text-sm font-semibold text-white transition hover:bg-brand-500"
+                        >
+                            Jadwalkan Konsultasi ↗
+                        </Link>
+                    </aside>
                 </div>
             </section>
         </AppShell>

--- a/tests/Unit/SiteContentTest.php
+++ b/tests/Unit/SiteContentTest.php
@@ -1,0 +1,48 @@
+<?php
+
+use App\Support\SiteContent;
+use Illuminate\Cache\ArrayStore;
+use Illuminate\Cache\Repository as CacheRepository;
+use Illuminate\Contracts\Filesystem\Factory as FilesystemFactory;
+use Illuminate\Database\ConnectionInterface;
+use Illuminate\Database\Query\Builder;
+use Mockery;
+
+it('returns default when site setting is missing', function () {
+    $connection = Mockery::mock(ConnectionInterface::class);
+    $builder = Mockery::mock(Builder::class);
+
+    $connection->shouldReceive('table')
+        ->once()
+        ->with('site_settings')
+        ->andReturn($builder);
+
+    $builder->shouldReceive('select')
+        ->once()
+        ->with('value_json')
+        ->andReturnSelf();
+
+    $builder->shouldReceive('where')
+        ->once()
+        ->with('section', 'general')
+        ->andReturnSelf();
+
+    $builder->shouldReceive('where')
+        ->once()
+        ->with('key', 'tagline')
+        ->andReturnSelf();
+
+    $builder->shouldReceive('first')
+        ->once()
+        ->andReturn(null);
+
+    $cache = new CacheRepository(new ArrayStore());
+    $storage = Mockery::mock(FilesystemFactory::class);
+
+    $siteContent = new SiteContent($connection, $cache, $storage);
+
+    expect($siteContent->getSetting('general', 'tagline', 'default value'))
+        ->toBe('default value');
+
+    Mockery::close();
+});


### PR DESCRIPTION
## Summary
- add an admin content editor with hero uploads, highlight builders, agenda/news controls, and testimonial management backed by FormData submissions
- refactor post, event, vocational, and general setting forms to support file previews, dynamic repeaters, and toast feedback while sending multipart payloads
- surface richer scheduling, SEO, and media metadata controls so admin updates align with the structured media and setting helpers

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68e3b31a361c83319abf53b61302a559